### PR TITLE
Allow advertising of globals

### DIFF
--- a/R/environment.R
+++ b/R/environment.R
@@ -55,7 +55,6 @@ hipercow_environment_create <- function(name = "default", packages = NULL,
   ## look at this later, but literally noone wants it!
   path <- file.path(root$path$environments, name)
   exists <- file.exists(path)
-  prev <- if (exists) readRDS(path) else NULL
 
   if (exists && identical(readRDS(path), ret)) {
     cli::cli_alert_info("Environment '{name}' is unchanged")

--- a/man/hipercow_environment.Rd
+++ b/man/hipercow_environment.Rd
@@ -12,6 +12,7 @@ hipercow_environment_create(
   name = "default",
   sources = NULL,
   packages = NULL,
+  globals = NULL,
   overwrite = TRUE,
   root = NULL
 )
@@ -39,6 +40,10 @@ task. These will be loaded with \code{library()} before the \code{sources}
 are sourced.  If you need to attach a package \emph{after} a script
 for some reason, just call \code{library} yourself within one of your
 \code{source} files.}
+
+\item{globals}{Names of global objects that we can assume exist
+within this environment.  This might include function
+definitions or large data objects.}
 
 \item{overwrite}{On environment creation, replace an environment
 with the same name.}

--- a/man/hipercow_environment.Rd
+++ b/man/hipercow_environment.Rd
@@ -10,8 +10,8 @@
 \usage{
 hipercow_environment_create(
   name = "default",
-  sources = NULL,
   packages = NULL,
+  sources = NULL,
   globals = NULL,
   overwrite = TRUE,
   root = NULL
@@ -30,20 +30,24 @@ hipercow_environment_exists(name = "default", root = NULL)
 special; this is the environment that will be used by default
 (hence the name!).}
 
-\item{sources}{Files to source before starting a task. These will
-be sourced into the global (or execution) environment of the
-task. The paths must be relative to the hipercow root, not the
-working directory.}
-
 \item{packages}{Packages to be \emph{attached} before starting a
 task. These will be loaded with \code{library()} before the \code{sources}
 are sourced.  If you need to attach a package \emph{after} a script
 for some reason, just call \code{library} yourself within one of your
 \code{source} files.}
 
+\item{sources}{Files to source before starting a task. These will
+be sourced into the global (or execution) environment of the
+task. The paths must be relative to the hipercow root, not the
+working directory.}
+
 \item{globals}{Names of global objects that we can assume exist
 within this environment.  This might include function
-definitions or large data objects.}
+definitions or large data objects.  The special value \code{TRUE}
+triggers automatic detection of objects within your environment
+(this takes a few seconds and requires that the environment is
+constructable on your local machine too, so is not currently
+enabled by default).}
 
 \item{overwrite}{On environment creation, replace an environment
 with the same name.}

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -1,10 +1,11 @@
 test_that("can construct an environment", {
-  env <- new_environment("foo", NULL, NULL)
+  env <- new_environment("foo", NULL, NULL, NULL)
   expect_s3_class(env, "hipercow_environment")
-  expect_setequal(names(env), c("name", "packages", "sources"))
+  expect_setequal(names(env), c("name", "packages", "sources", "globals"))
   expect_equal(env$name, "foo")
   expect_null(env$packages)
   expect_null(env$sources)
+  expect_null(env$globals)
 })
 
 
@@ -12,10 +13,12 @@ test_that("can construct a nontrivial environment", {
   path <- withr::local_tempfile()
   root <- init_quietly(path)
   file.create(file.path(path, c("a.R", "b.R")))
-  env <- new_environment("foo", c("a.R", "b.R"), c("x", "y", "z"), root)
+  env <- new_environment("foo", c("a.R", "b.R"), c("x", "y", "z"),
+                         c("i", "j", "k"), root)
   expect_equal(env$name, "foo")
   expect_equal(env$sources, c("a.R", "b.R"))
   expect_equal(env$packages, c("x", "y", "z"))
+  expect_equal(env$globals, c("i", "j", "k"))
 })
 
 
@@ -31,6 +34,7 @@ test_that("can print empty environments", {
   expect_match(msg, "hipercow environment 'default'", all = FALSE)
   expect_match(msg, "packages: (none)", all = FALSE, fixed = TRUE)
   expect_match(msg, "sources: (none)", all = FALSE, fixed = TRUE)
+  expect_match(msg, "globals: (none)", all = FALSE, fixed = TRUE)
 })
 
 
@@ -42,12 +46,14 @@ test_that("can print nontrivial environments", {
     hipercow_environment_create("foo",
                               packages = c("x", "y", "z"),
                               sources = c("a.R", "b.R", "c.R"),
+                              globals = c("i", "j", "k"),
                               root = path))
   msg <- capture_messages(
     hipercow_environment_show("foo", root))
   expect_match(msg, "hipercow environment 'foo'", all = FALSE)
   expect_match(msg, "packages: x, y, z", all = FALSE, fixed = TRUE)
   expect_match(msg, "sources: a.R, b.R, c.R", all = FALSE, fixed = TRUE)
+  expect_match(msg, "globals: i, j, k", all = FALSE, fixed = TRUE)
 })
 
 
@@ -69,7 +75,7 @@ test_that("can create environment in root", {
     hipercow_environment_create(packages = pkgs, root = path),
     "Created environment 'default'")
   expect_equal(environment_load("default", root),
-               new_environment("default", NULL, pkgs, root))
+               new_environment("default", NULL, pkgs, NULL, root))
 })
 
 
@@ -84,17 +90,17 @@ test_that("can update existing environment in root", {
     hipercow_environment_create(name = "foo", packages = pkgs1, root = path),
     "Created environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs1, root))
+               new_environment("foo", NULL, pkgs1, NULL, root))
   expect_message(
     hipercow_environment_create(name = "foo", packages = pkgs2, root = path),
     "Updated environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs2, root))
+               new_environment("foo", NULL, pkgs2, NULL, root))
   expect_message(
     hipercow_environment_create(name = "foo", packages = pkgs2, root = path),
     "Environment 'foo' is unchanged")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs2, root))
+               new_environment("foo", NULL, pkgs2, NULL, root))
   expect_true(hipercow_environment_exists("foo", path))
   expect_equal(hipercow_environment_list(path), c("default", "foo"))
 })
@@ -110,7 +116,7 @@ test_that("can prevent overwriting of an environment", {
                               overwrite = FALSE, root = path),
     "Created environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs1, root))
+               new_environment("foo", NULL, pkgs1, NULL, root))
   expect_error(
     hipercow_environment_create(name = "foo", packages = pkgs2,
                               overwrite = FALSE, root = path),
@@ -123,7 +129,7 @@ test_that("creating initial default does not count as overwriting", {
   root <- init_quietly(path)
   pkgs <- c("x", "y")
   expect_equal(environment_load("default", root),
-               new_environment("default", NULL, NULL, root))
+               new_environment("default", NULL, NULL, NULL, root))
   expect_message(
     hipercow_environment_create(name = "default", packages = pkgs,
                               overwrite = FALSE, root = path),

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -13,7 +13,7 @@ test_that("can construct a nontrivial environment", {
   path <- withr::local_tempfile()
   root <- init_quietly(path)
   file.create(file.path(path, c("a.R", "b.R")))
-  env <- new_environment("foo", c("a.R", "b.R"), c("x", "y", "z"),
+  env <- new_environment("foo", c("x", "y", "z"), c("a.R", "b.R"),
                          c("i", "j", "k"), root)
   expect_equal(env$name, "foo")
   expect_equal(env$sources, c("a.R", "b.R"))
@@ -75,7 +75,7 @@ test_that("can create environment in root", {
     hipercow_environment_create(packages = pkgs, root = path),
     "Created environment 'default'")
   expect_equal(environment_load("default", root),
-               new_environment("default", NULL, pkgs, NULL, root))
+               new_environment("default", pkgs, NULL, NULL, root))
 })
 
 
@@ -90,17 +90,17 @@ test_that("can update existing environment in root", {
     hipercow_environment_create(name = "foo", packages = pkgs1, root = path),
     "Created environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs1, NULL, root))
+               new_environment("foo", pkgs1, NULL, NULL, root))
   expect_message(
     hipercow_environment_create(name = "foo", packages = pkgs2, root = path),
     "Updated environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs2, NULL, root))
+               new_environment("foo", pkgs2, NULL, NULL, root))
   expect_message(
     hipercow_environment_create(name = "foo", packages = pkgs2, root = path),
     "Environment 'foo' is unchanged")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs2, NULL, root))
+               new_environment("foo", pkgs2, NULL, NULL, root))
   expect_true(hipercow_environment_exists("foo", path))
   expect_equal(hipercow_environment_list(path), c("default", "foo"))
 })
@@ -116,7 +116,7 @@ test_that("can prevent overwriting of an environment", {
                               overwrite = FALSE, root = path),
     "Created environment 'foo'")
   expect_equal(environment_load("foo", root),
-               new_environment("foo", NULL, pkgs1, NULL, root))
+               new_environment("foo", pkgs1, NULL, NULL, root))
   expect_error(
     hipercow_environment_create(name = "foo", packages = pkgs2,
                               overwrite = FALSE, root = path),
@@ -222,4 +222,27 @@ test_that("can delete environments", {
     hipercow_environment_delete("foo", path),
     "Deleting environment 'foo' (if it existed)", fixed = TRUE)
   expect_equal(hipercow_environment_list(path), "default")
+})
+
+
+test_that("can discover globals in environment", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  writeLines(c("a <- 1", "b <- 2"), file.path(path, "src.R"))
+  res <- evaluate_promise(
+    discover_globals("myenv", NULL, "src.R", root))
+  expect_equal(res$result, c("a", "b"))
+  expect_match(res$messages[[1]], "Creating 'myenv' in a clean R session")
+  expect_match(res$messages[[2]], "Found 2 symbols")
+})
+
+
+test_that("special value 'TRUE' triggers global environment build", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  writeLines("a <- 1", file.path(path, "src.R"))
+  res <- evaluate_promise(new_environment("default", NULL, "src.R", TRUE, root))
+  expect_equal(res$result$globals, "a")
+  expect_match(res$messages[[1]], "Creating 'default' in a clean R session")
+  expect_match(res$messages[[2]], "Found 1 symbol\\b")
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -144,7 +144,7 @@ test_that("can call provision", {
 
   hipercow_provision(root = path_here, show_log = FALSE)
   mockery::expect_called(mock_provision, 1)
-  environment <- new_environment("default", NULL, NULL)
+  environment <- new_environment("default", NULL, NULL, NULL)
   expect_equal(
     mockery::mock_args(mock_provision)[[1]],
     list(NULL, config, path_root, environment, show_log = FALSE))

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -144,7 +144,7 @@ test_that("can call provision", {
 
   hipercow_provision(root = path_here, show_log = FALSE)
   mockery::expect_called(mock_provision, 1)
-  environment <- new_environment("default", NULL, NULL, NULL)
+  environment <- new_environment("default", NULL, NULL, NULL, NULL)
   expect_equal(
     mockery::mock_args(mock_provision)[[1]],
     list(NULL, config, path_root, environment, show_log = FALSE))


### PR DESCRIPTION
This PR lets the user declare what variables we can rely on to exist within their created environment. There's a special value `TRUE` here which just builds the env and works it out