### PR TITLE
Use globals within a task

### DIFF
--- a/R/environment.R
+++ b/R/environment.R
@@ -220,3 +220,32 @@ discover_globals <- function(name, packages, sources, root) {
   cli::cli_alert_success("Found {n} {cli::qty(n)}symbol{?s}")
   res
 }
+
+
+check_globals <- function(globals, envir, call = call) {
+  if (length(globals) == 0) {
+    return()
+  }
+  values <- rlang::env_get_list(envir, names(globals), inherit = TRUE,
+                                last = topenv())
+  hashes <- vcapply(values, rlang::hash)
+  err <- hashes != globals
+  if (any(err)) {
+    nms <- names(globals)[err]
+    n <- length(err)
+    hint <-
+    cli::cli_abort(
+      c("Unexpected value{?s} for global variable{?s}: {squote(nms)}",
+        i = paste(
+          "{cli::qty(n)}When we loaded your environment to run this task,",
+          "the value of {?this variable/these variables} differed from the",
+          "value we saw when saving the task originally.",
+          "{?This variable/These variables} were likely created when",
+          "sourcing your environment source scripts, so it's possible",
+          "that you changed these scripts since creating the task?"),
+        i = paste(
+          "Disable this check at task creation by setting the option",
+          "'hipercow.validate_globals' to FALSE")),
+      call = call)
+  }
+}

--- a/R/task.R
+++ b/R/task.R
@@ -499,7 +499,8 @@ task_variables <- function(names, envir, environment, root, call = NULL) {
 
     locals <- rlang::env_get_list(envir, nms_locals, inherit = TRUE,
                                   last = topenv())
-    if (getOption("hipercow.validate_globals", FALSE) && length(nms_globals)) {
+    validate_globals <- getOption("hipercow.validate_globals", FALSE)
+    if (validate_globals && length(nms_globals) > 0) {
       globals <- rlang::env_get_list(envir, nms_globals, inherit = TRUE,
                                      last = topenv())
       globals <- vcapply(globals, rlang::hash)

--- a/R/task.R
+++ b/R/task.R
@@ -164,6 +164,7 @@ task_eval <- function(id, envir = .GlobalEnv, root = NULL) {
 
   result <- rlang::try_fetch({
     environment_apply(data$environment, envir, root, top)
+    check_globals(data$variables$globals, envir, top)
     withr::local_dir(file.path(root$path$root, data$path))
     switch(
       data$type,


### PR DESCRIPTION
This PR allows using globals when running a task. Validation included, but optional (and off by default)