### PR TITLE
Drop 'name' argument from windows_path

### DIFF
--- a/R/windows.R
+++ b/R/windows.R
@@ -26,9 +26,6 @@ windows_credentials <- function() {
 ##' Describe a path mapping for use when setting up jobs on the cluster.
 ##' @title Describe a path mapping
 ##'
-##' @param name Name of this map.  Can be anything at all, and is used
-##'   for information purposes only.
-##'
 ##' @param path_local The point where the drive is attached locally.
 ##'   On Windows this will be something like "Q:/", on Mac something
 ##'   like "/Volumes/mountname", and on Linux it could be anything at
@@ -51,7 +48,7 @@ windows_credentials <- function() {
 ##'
 ##' @export
 ##' @author Rich FitzJohn
-windows_path <- function(name, path_local, path_remote, drive_remote) {
+windows_path <- function(path_local, path_remote, drive_remote) {
   ns <- ensure_package("hipercow.windows", rlang::current_env())
-  ns$windows_path(name, path_local, path_remote, drive_remote)
+  ns$windows_path(path_local, path_remote, drive_remote)
 }

--- a/drivers/windows/R/mounts.R
+++ b/drivers/windows/R/mounts.R
@@ -172,7 +172,7 @@ dide_add_extra_root_share <- function(shares, path_root,
   }
   drive <- available_drive(shares, mounts[i, "local"])
   c(shares,
-    list(windows_path("root", mounts[i, "local"], mounts[i, "remote"], drive)))
+    list(windows_path(mounts[i, "local"], mounts[i, "remote"], drive)))
 }
 
 

--- a/drivers/windows/R/paths.R
+++ b/drivers/windows/R/paths.R
@@ -1,5 +1,4 @@
-windows_path <- function(name, path_local, path_remote, drive_remote) {
-  assert_scalar_character(name)
+windows_path <- function(path_local, path_remote, drive_remote) {
   assert_scalar_character(path_local)
   assert_scalar_character(path_remote)
   assert_scalar_character(drive_remote)
@@ -31,7 +30,6 @@ windows_path <- function(name, path_local, path_remote, drive_remote) {
   }
 
   ret <- list(
-    name = name,
     path_remote = path_remote,
     path_local = clean_path_local(path_local),
     drive_remote = drive_remote)

--- a/drivers/windows/tests/testthat/helper-config.R
+++ b/drivers/windows/tests/testthat/helper-config.R
@@ -3,7 +3,7 @@ example_root <- function(mount_path, sub = "b/c") {
   path <- file.path(mount_path, sub)
   root <- suppressMessages(hipercow::hipercow_init(path))
   path <- normalize_path(path)
-  shares <- windows_path("home", mount_path, "//host/share/path", "X:")
+  shares <- windows_path(mount_path, "//host/share/path", "X:")
   suppressMessages(
     hipercow::hipercow_configure("windows", shares = shares, root = root))
   root

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -2,7 +2,7 @@ test_that("Can create configuration", {
   mount <- withr::local_tempfile()
   path <- file.path(mount, "b", "c")
   root <- suppressMessages(hipercow::hipercow_init(path))
-  shares <- windows_path("home", mount, "//host/share/path", "X:")
+  shares <- windows_path(mount, "//host/share/path", "X:")
   config <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
   expect_setequal(
     names(config),
@@ -31,7 +31,7 @@ test_that("can configure a root", {
   mount <- withr::local_tempfile()
   path <- file.path(mount, "b", "c")
   root <- suppressMessages(hipercow::hipercow_init(path))
-  shares <- windows_path("home", mount, "//host/share/path", "X:")
+  shares <- windows_path(mount, "//host/share/path", "X:")
   cmp <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
 
   suppressMessages(

--- a/drivers/windows/tests/testthat/test-mounts.R
+++ b/drivers/windows/tests/testthat/test-mounts.R
@@ -11,7 +11,6 @@ test_that("can locate root path among paths", {
   paths <- clean_path_local(paths)
   mounts[, "local"] <- clean_path_local(mounts[, "local"])
   shares <- Map(windows_path,
-                basename(mounts[, "local"]),
                 mounts[, "local"],
                 mounts[, "remote"],
                 c("X:", "Y:", "Z:"))
@@ -19,8 +18,7 @@ test_that("can locate root path among paths", {
   ## their working directory
   expect_equal(dide_add_extra_root_share(shares, paths[[1]], mounts),
                shares)
-  result <- windows_path("root", mounts[1, "local"], mounts[1, "remote"],
-                         "V:")
+  result <- windows_path(mounts[1, "local"], mounts[1, "remote"], "V:")
 
   ## More commonly, we work out where the working directory is from
   ## their mounts:
@@ -227,7 +225,6 @@ test_that("Validate additional shares", {
   path <- withr::local_tempfile()
   mounts <- example_mounts(path)
   shares <- Map(windows_path,
-                c("other", "home", "project", "temp", "sk"),
                 mounts[, "local"],
                 mounts[, "remote"],
                 c("O:", "Q:", "P:", "T:", "K:"),
@@ -247,7 +244,6 @@ test_that("Prevent duplicated drives", {
   path <- withr::local_tempfile()
   mounts <- example_mounts(path)
   shares <- Map(windows_path,
-                c("a", "b", "c"),
                 mounts[1:3, "local"],
                 mounts[1:3, "remote"],
                 c("X:", "Y:", "X:"))

--- a/drivers/windows/tests/testthat/test-paths.R
+++ b/drivers/windows/tests/testthat/test-paths.R
@@ -1,6 +1,6 @@
 test_that("can create a path mapping", {
   p <- getwd()
-  m <- windows_path("home", p, "//fi--san03/homes/bob", "Q:")
+  m <- windows_path(p, "//fi--san03/homes/bob", "Q:")
   expect_s3_class(m, "windows_path")
   str <- as.character(m)
   expect_match(str, "\\(local\\) .+ => .+ \\(remote\\)")
@@ -9,19 +9,19 @@ test_that("can create a path mapping", {
 
 test_that("cannot create a path mapping on I:", {
   p <- getwd()
-  expect_error(windows_path("home", p, "//fi--san03/homes/bob", "I:"),
+  expect_error(windows_path(p, "//fi--san03/homes/bob", "I:"),
                "You cannot use I:")
 })
 
 test_that("can validate creation of path mapping", {
   expect_error(
-    windows_path("home", tempfile(), "//fi--san03/homes/bob", "Q:"),
+    windows_path(tempfile(), "//fi--san03/homes/bob", "Q:"),
     "Local mount point does not exist.")
   expect_error(
-    windows_path("home", "Q:", "Q://fi--san03/homes/bob", "Q:"),
+    windows_path("Q:", "Q://fi--san03/homes/bob", "Q:"),
     "path_remote must be a network path")
   expect_error(
-    windows_path("home", getwd(), "//fi--san03/homes/bob", "Q"),
+    windows_path(getwd(), "//fi--san03/homes/bob", "Q"),
     "drive_remote must be of the form 'X:'")
 })
 
@@ -62,8 +62,8 @@ test_that("Can detect a path into a share", {
   t <- withr::local_tempdir()
   t <- normalize_path(t)
   shares <- list(
-    windows_path("home", p, "//fi--san03/homes/bob", "Q:"),
-    windows_path("temp", tempdir(), "//fi--san03/tmp", "T:"))
+    windows_path(p, "//fi--san03/homes/bob", "Q:"),
+    windows_path(tempdir(), "//fi--san03/tmp", "T:"))
 
   x <- prepare_path(t, shares)
   expect_equal(x$rel, basename(t))
@@ -95,8 +95,8 @@ test_that("Can create a remote path", {
   t <- withr::local_tempdir()
   t <- normalize_path(t)
   shares <- list(
-    home = windows_path("home", p, "//fi--san03/homes/bob", "Q:"),
-    temp = windows_path("temp", tempdir(), "//fi--san03/tmp", "T:"))
+    home = windows_path(p, "//fi--san03/homes/bob", "Q:"),
+    temp = windows_path(tempdir(), "//fi--san03/tmp", "T:"))
   res <- remote_path(t, shares)
   expect_equal(
     res,

--- a/drivers/windows/tests/testthat/test-web.R
+++ b/drivers/windows/tests/testthat/test-web.R
@@ -363,6 +363,7 @@ test_that("load endpoints are correct", {
 
 
 test_that("version endpoint can be called", {
+  testthat::skip_if_offline()
   client <- web_client$new("bob")
   versions <- client$r_versions()
   expect_s3_class(versions, "numeric_version")

--- a/man/windows_path.Rd
+++ b/man/windows_path.Rd
@@ -4,12 +4,9 @@
 \alias{windows_path}
 \title{Describe a path mapping}
 \usage{
-windows_path(name, path_local, path_remote, drive_remote)
+windows_path(path_local, path_remote, drive_remote)
 }
 \arguments{
-\item{name}{Name of this map.  Can be anything at all, and is used
-for information purposes only.}
-
 \item{path_local}{The point where the drive is attached locally.
 On Windows this will be something like "Q:/", on Mac something
 like "/Volumes/mountname", and on Linux it could be anything at

--- a/tests/testthat/test-windows.R
+++ b/tests/testthat/test-windows.R
@@ -3,7 +3,7 @@ test_that("windows_path calls hipercow.windows", {
   mock_ensure_package <- mockery::mock(mock_pkg)
   mockery::stub(windows_path, "ensure_package", mock_ensure_package)
   p <- getwd()
-  windows_path("home", p, "//fi--san03/homes/bob", "Q:")
+  windows_path(p, "//fi--san03/homes/bob", "Q:")
 
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
@@ -12,7 +12,7 @@ test_that("windows_path calls hipercow.windows", {
 
   mockery::expect_called(mock_pkg$windows_path, 1)
   expect_equal(mockery::mock_args(mock_pkg$windows_path)[[1]],
-               list("home", p, "//fi--san03/homes/bob", "Q:"))
+               list(p, "//fi--san03/homes/bob", "Q:"))
 })
 
 


### PR DESCRIPTION
Fairly mechanical - this is now unused everywhere so just drop it.