### PR TITLE
Allow preventing driver load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ roxygen:
 	${RSCRIPT} -e "devtools::document()"
 
 install:
-	R CMD INSTALL .
+	R CMD INSTALL . drivers/windows
 
 build:
 	R CMD build .

--- a/R/configure.R
+++ b/R/configure.R
@@ -94,6 +94,12 @@ hipercow_driver <- function(configure, submit, status, log, result, cancel,
 
 
 hipercow_driver_load <- function(driver, call) {
+  if (!allow_load_drivers()) {
+    cli::cli_abort(
+      c("Trying to load a driver from code that should not do so",
+        i = "This is a hipercow bug, please report, along with the traceback"),
+      call = call)
+  }
   if (is.null(cache$drivers[[driver]])) {
     valid <- "windows"
     assert_scalar_character(driver)
@@ -162,4 +168,12 @@ hipercow_driver_prepare <- function(driver, root, call) {
   list(name = driver,
        driver = hipercow_driver_load(driver, call),
        config = root$config[[driver]])
+}
+
+
+allow_load_drivers <- function() {
+  if (is.null(cache$allow_load_drivers)) {
+    cache$allow_load_drivers <- Sys.getenv("HIPERCOW_NO_DRIVERS", "0") != "1"
+  }
+  cache$allow_load_drivers
 }

--- a/R/configure.R
+++ b/R/configure.R
@@ -129,7 +129,6 @@ hipercow_driver_create <- function(name, call = NULL) {
 
 
 hipercow_driver_select <- function(name, root, call = NULL) {
-
   valid <- names(root$config)
   if (is.null(name)) {
     if (length(valid) == 0) {

--- a/R/task.R
+++ b/R/task.R
@@ -367,6 +367,7 @@ task_result <- function(id, root = NULL) {
 ##' @rdname task_log
 ##' @export
 task_log_show <- function(id, root = NULL) {
+  root <- hipercow_root(root)
   result <- task_log_fetch(id, root)
   if (is.null(result)) {
     cli::cli_alert_danger("No logs for task '{id}' (yet?)")
@@ -381,6 +382,7 @@ task_log_show <- function(id, root = NULL) {
 ##' @rdname task_log
 ##' @export
 task_log_value <- function(id, root = NULL) {
+  root <- hipercow_root(root)
   task_log_fetch(id, root)
 }
 

--- a/R/task.R
+++ b/R/task.R
@@ -265,24 +265,27 @@ task_status <- function(id, root = NULL) {
   }
 
   if (any(i)) {
-    task_driver <- vcapply(id[i], task_get_driver, root = root)
-    for (driver in unique(na_omit(task_driver))) {
-      dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-      j <- task_driver == driver
-      status_ij <- dat$driver$status(id[i][j], dat$config, root$path$root)
-      for (s in names(terminal)) {
-        if (any(k <- !is.na(status_ij) & status_ij == s)) {
-          file.create(file.path(path[i][j][k], terminal[[s]]))
+    if (allow_load_drivers()) {
+      task_driver <- vcapply(id[i], task_get_driver, root = root)
+      for (driver in unique(na_omit(task_driver))) {
+        dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
+        j <- task_driver == driver
+        status_ij <- dat$driver$status(id[i][j], dat$config, root$path$root)
+        for (s in names(terminal)) {
+          if (any(k <- !is.na(status_ij) & status_ij == s)) {
+            file.create(file.path(path[i][j][k], terminal[[s]]))
+          }
         }
+        status[i][j] <- status_ij
       }
-      status[i][j] <- status_ij
     }
 
-    ## Final set were not submitted; these must be on disk only and we
-    ## know that they are not in a terminal state:
+    ## Final set were not submitted (or we just can't load the
+    ## driver); these must be on disk only and we know that they are
+    ## not in a terminal state:
     i <- is.na(status)
     if (any(i)) {
-      for (s in c(STATUS_RUNNING, STATUS_CREATED)) {
+      for (s in c(STATUS_RUNNING, STATUS_SUBMITTED, STATUS_CREATED)) {
         if (any(j <- file.exists(file.path(path[i], s)))) {
           status[i][j] <- sub("status-", "", s)
           i <- is.na(status)
@@ -333,7 +336,11 @@ task_result <- function(id, root = NULL) {
   path_result <- file.path(path, RESULT)
   if (!file.exists(path_result)) {
     status <- task_status(id, root)
-    task_driver <- vcapply(id, task_get_driver, root = root)
+    if (allow_load_drivers()) {
+      task_driver <- task_get_driver(id, root = root)
+    } else {
+      task_driver <- NA
+    }
     if (is.na(task_driver) || !(status %in% c("success", "failure"))) {
       cli::cli_abort(
         "Result for task '{id}' not available, status is '{status}'")

--- a/drivers/windows/R/batch.R
+++ b/drivers/windows/R/batch.R
@@ -1,7 +1,7 @@
 write_batch_task_run <- function(task_id, config, path_root) {
   data <- template_data(config, path_root)
   data$task_id <- task_id
-  str <- glue_whisker(read_template("task_run"), data)
+  str <- glue_whisker(read_template("task_run.bat"), data)
   path <- file.path(path_root, "hipercow", "tasks", task_id, BATCH_RUN)
   writeLines(str, path)
   path
@@ -11,7 +11,7 @@ write_batch_task_run <- function(task_id, config, path_root) {
 write_batch_provision_script <- function(id, config, path_root) {
   data <- template_data(config, path_root)
   data$id <- id
-  str <- glue_whisker(read_template("provision"), data)
+  str <- glue_whisker(read_template("provision.bat"), data)
   path_job <- file.path(path_root, "hipercow", "provision", id)
   path <- file.path(path_job, "provision.bat")
   fs::dir_create(path_job)
@@ -21,7 +21,7 @@ write_batch_provision_script <- function(id, config, path_root) {
 
 
 read_template <- function(name) {
-  read_lines(hipercow_windows_file(sprintf("templates/%s.bat", name)))
+  read_lines(hipercow_windows_file(sprintf("templates/%s", name)))
 }
 
 
@@ -40,9 +40,7 @@ template_data <- function(config, path_root) {
 
   ## Semicolon delimited list on windows; see "Managing libraries" in
   ## https://cran.r-project.org/doc/manuals/r-release/R-admin.html
-  hipercow_library <- paste(unix_path_slashes(config$path_lib),
-                          unix_path_slashes(config$path_bootstrap),
-                          sep = ";")
+  hipercow_library <- paste(config$path_lib, path_bootstrap(config), sep = ";")
 
   list(
     hostname = hostname(),
@@ -55,4 +53,11 @@ template_data <- function(config, path_root) {
     hipercow_root_path = paste0("\\", windows_path_slashes(hipercow_root$rel)),
     hipercow_library = hipercow_library,
     cluster_name = config$cluster)
+}
+
+
+path_bootstrap <- function(config) {
+  use_development <- getOption("hipercow.development", FALSE)
+  base <- if (use_development) "bootstrap-dev" else "bootstrap"
+  sprintf("I:/%s/%s", base, version_string(config$r_version, "."))
 }

--- a/drivers/windows/R/bootstrap.R
+++ b/drivers/windows/R/bootstrap.R
@@ -1,10 +1,12 @@
-bootstrap_update <- function(root = NULL) {
+bootstrap_update <- function(development = FALSE, root = NULL) {
   path_script <- "hipercow/bootstrap-windows.R"
   path_root <- hipercow:::hipercow_root(root)$path$root
   path_script_abs <- file.path(path_root, path_script)
   dir.create(dirname(path_script_abs), FALSE, TRUE)
+  bootstrap <- read_template("bootstrap.R")
+  path_bootstrap <- if (development) "bootstrap-dev" else "bootstrap"
   writelines_if_different(
-    readLines(hipercow_windows_file("bootstrap.R")),
+    glue_whisker(bootstrap, list(bootstrap_path = path_bootstrap)),
     path_script_abs)
   hipercow::hipercow_provision("script", script = path_script, root = root)
 }

--- a/drivers/windows/R/bootstrap.R
+++ b/drivers/windows/R/bootstrap.R
@@ -1,12 +1,17 @@
-bootstrap_update <- function(development = FALSE, root = NULL) {
+bootstrap_update <- function(development = NULL, root = NULL) {
   path_script <- "hipercow/bootstrap-windows.R"
   path_root <- hipercow:::hipercow_root(root)$path$root
   path_script_abs <- file.path(path_root, path_script)
   dir.create(dirname(path_script_abs), FALSE, TRUE)
   bootstrap <- read_template("bootstrap.R")
-  path_bootstrap <- if (development) "bootstrap-dev" else "bootstrap"
-  writelines_if_different(
-    glue_whisker(bootstrap, list(bootstrap_path = path_bootstrap)),
-    path_script_abs)
+  if (is.null(development)) {
+    data <- list(bootstrap_path = "bootstrap",
+                 development_ref = "NULL")
+  } else {
+    data <- list(bootstrap_path = "bootstrap-dev",
+                 development_ref = dquote(development))
+  }
+  writelines_if_different(glue_whisker(bootstrap, data),
+                          path_script_abs)
   hipercow::hipercow_provision("script", script = path_script, root = root)
 }

--- a/drivers/windows/R/config.R
+++ b/drivers/windows/R/config.R
@@ -4,6 +4,8 @@ windows_configure <- function(shares = NULL, r_version = NULL) {
   r_version_str <- version_string(r_version, ".")
   path_lib <- file.path("hipercow", "lib", "windows", r_version_str)
   path_bootstrap <- sprintf("I:/bootstrap/%s", r_version_str)
+  stopifnot(file.exists(file.path(path, "hipercow.json")))
+  fs::dir_create(file.path(path, path_lib))
   list(cluster = "wpia-hn",
        template = "AllNodes",
        shares = dide_cluster_paths(shares, path),

--- a/drivers/windows/R/config.R
+++ b/drivers/windows/R/config.R
@@ -3,15 +3,13 @@ windows_configure <- function(shares = NULL, r_version = NULL) {
   r_version <- select_r_version(r_version)
   r_version_str <- version_string(r_version, ".")
   path_lib <- file.path("hipercow", "lib", "windows", r_version_str)
-  path_bootstrap <- sprintf("I:/bootstrap/%s", r_version_str)
   stopifnot(file.exists(file.path(path, "hipercow.json")))
   fs::dir_create(file.path(path, path_lib))
   list(cluster = "wpia-hn",
        template = "AllNodes",
        shares = dide_cluster_paths(shares, path),
        r_version = r_version,
-       path_lib = path_lib,
-       path_bootstrap = path_bootstrap)
+       path_lib = unix_path_slashes(path_lib))
 }
 
 

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -4,7 +4,7 @@ windows_provision <- function(method, config, path_root, environment, ...) {
     method,
     path = path_root,
     path_lib = config$path_lib,
-    path_bootstrap = config$path_bootstrap,
+    path_bootstrap = path_bootstrap(config),
     environment = environment,
     ...)
 

--- a/drivers/windows/R/util.R
+++ b/drivers/windows/R/util.R
@@ -39,6 +39,11 @@ squote <- function(x) {
 }
 
 
+dquote <- function(x) {
+  sprintf('"%s"', x)
+}
+
+
 is_windows <- function() {
   Sys.info()[["sysname"]] == "Windows"
 }

--- a/drivers/windows/inst/templates/bootstrap.R
+++ b/drivers/windows/inst/templates/bootstrap.R
@@ -1,4 +1,4 @@
-path <- sprintf("I:/bootstrap/%s",
+path <- sprintf("I:/{{bootstrap_path}}/%s",
                 paste(unclass(getRversion())[[1]], collapse = "."))
 path_next <- sprintf("%s-next", path)
 path_prev <- sprintf("%s-prev", path)

--- a/drivers/windows/inst/templates/bootstrap.R
+++ b/drivers/windows/inst/templates/bootstrap.R
@@ -20,11 +20,23 @@ ok <- all(file.exists(file.path(path_next, pkgs, "Meta", "package.rds")))
 if (!ok) {
   stop("Failed to install all packages")
 }
+
 curr_exists <- file.exists(path)
 if (curr_exists) {
-  file.rename(path, path_prev)
+  # Default behaviour is to warn and just continue if the rename
+  # fails, which is wild, and also terrible.
+  stopifnot(file.rename(path, path_prev))
 }
-file.rename(path_next, path)
+stopifnot(file.rename(path_next, path))
 if (curr_exists) {
   unlink(path_prev, recursive = TRUE)
+}
+
+if (!is.null({{development_ref}})) {
+  .libPaths(path, FALSE)
+  ## We need to install this directly into the final library,
+  ## otherwise we can't move things over because "remotes" will have
+  ## been loaded and that creates a lock.
+  remotes::install_github("mrc-ide/hipercow", ref = {{development_ref}},
+                          upgrade = FALSE)
 }

--- a/drivers/windows/inst/templates/task_run.bat
+++ b/drivers/windows/inst/templates/task_run.bat
@@ -15,6 +15,7 @@ cd {{hipercow_root_path}}
 ECHO working directory: %CD%
 
 set R_LIBS_USER={{hipercow_library}}
+set HIPERCOW_NO_DRIVERS=1
 
 ECHO this is a single task
 

--- a/drivers/windows/tests/testthat/setup.R
+++ b/drivers/windows/tests/testthat/setup.R
@@ -1,0 +1,4 @@
+withr::local_options(
+  hipercow.development = FALSE,
+  .local_envir = teardown_env()
+)

--- a/drivers/windows/tests/testthat/test-bootstrap.R
+++ b/drivers/windows/tests/testthat/test-bootstrap.R
@@ -5,11 +5,46 @@ test_that("can run bootstrap", {
   mockery::stub(bootstrap_update, "hipercow::hipercow_provision",
                 mock_hipercow_provision)
 
-  bootstrap_update(root)
+  bootstrap_update(root = root)
   mockery::expect_called(mock_hipercow_provision, 1)
   expect_true(file.exists(
     file.path(root$path$root, "hipercow", "bootstrap-windows.R")))
   expect_equal(
     mockery::mock_args(mock_hipercow_provision)[[1]],
     list("script", script = "hipercow/bootstrap-windows.R", root = root))
+  s <- readLines(file.path(root$path$root, "hipercow", "bootstrap-windows.R"))
+  expect_match(s[[1]], "I:/bootstrap/")
+})
+
+
+test_that("can run development bootstrap", {
+  mount <- withr::local_tempfile()
+  root <- example_root(mount, "b/c")
+  mock_hipercow_provision <- mockery::mock()
+  mockery::stub(bootstrap_update, "hipercow::hipercow_provision",
+                mock_hipercow_provision)
+
+  bootstrap_update(development = TRUE, root = root)
+  mockery::expect_called(mock_hipercow_provision, 1)
+  expect_true(file.exists(
+    file.path(root$path$root, "hipercow", "bootstrap-windows.R")))
+  expect_equal(
+    mockery::mock_args(mock_hipercow_provision)[[1]],
+    list("script", script = "hipercow/bootstrap-windows.R", root = root))
+  s <- readLines(file.path(root$path$root, "hipercow", "bootstrap-windows.R"))
+  expect_match(s[[1]], "I:/bootstrap-dev/")
+})
+
+
+test_that("respond to option to select dev bootstrap", {
+  config <- list(r_version = numeric_version("4.3.2"))
+  withr::with_options(
+    list(hipercow.development = NULL),
+    expect_equal(path_bootstrap(config), "I:/bootstrap/4.3.2"))
+  withr::with_options(
+    list(hipercow.development = FALSE),
+    expect_equal(path_bootstrap(config), "I:/bootstrap/4.3.2"))
+  withr::with_options(
+    list(hipercow.development = TRUE),
+    expect_equal(path_bootstrap(config), "I:/bootstrap-dev/4.3.2"))
 })

--- a/drivers/windows/tests/testthat/test-bootstrap.R
+++ b/drivers/windows/tests/testthat/test-bootstrap.R
@@ -24,7 +24,7 @@ test_that("can run development bootstrap", {
   mockery::stub(bootstrap_update, "hipercow::hipercow_provision",
                 mock_hipercow_provision)
 
-  bootstrap_update(development = TRUE, root = root)
+  bootstrap_update(development = "mrc-4827", root = root)
   mockery::expect_called(mock_hipercow_provision, 1)
   expect_true(file.exists(
     file.path(root$path$root, "hipercow", "bootstrap-windows.R")))
@@ -33,6 +33,10 @@ test_that("can run development bootstrap", {
     list("script", script = "hipercow/bootstrap-windows.R", root = root))
   s <- readLines(file.path(root$path$root, "hipercow", "bootstrap-windows.R"))
   expect_match(s[[1]], "I:/bootstrap-dev/")
+  expect_match(
+    s,
+    'remotes::install_github("mrc-ide/hipercow", ref = "mrc-4827",',
+    fixed = TRUE, all = FALSE)
 })
 
 

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -6,14 +6,12 @@ test_that("Can create configuration", {
   config <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
   expect_setequal(
     names(config),
-    c("cluster", "template", "shares", "r_version",
-      "path_lib", "path_bootstrap"))
+    c("cluster", "template", "shares", "r_version", "path_lib"))
   expect_equal(config$cluster, "wpia-hn")
   expect_equal(config$template, "AllNodes")
   expect_equal(config$shares, list(shares))
   expect_equal(config$r_version, numeric_version("4.3.0"))
   expect_equal(config$path_lib, "hipercow/lib/windows/4.3.0")
-  expect_equal(config$path_bootstrap, "I:/bootstrap/4.3.0")
 })
 
 

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -1,7 +1,7 @@
 test_that("Can create configuration", {
   mount <- withr::local_tempfile()
   path <- file.path(mount, "b", "c")
-  fs::dir_create(path)
+  root <- suppressMessages(hipercow::hipercow_init(path))
   shares <- windows_path("home", mount, "//host/share/path", "X:")
   config <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
   expect_setequal(

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -152,3 +152,27 @@ test_that("informative messages on configuration", {
     hipercow_configure("elsewhere", path = path_elsewhere, root = path_here),
     "Updated configuration for 'elsewhere'")
 })
+
+
+test_that("prevent loading of drivers", {
+  elsewhere_register()
+  path_here <- withr::local_tempdir()
+  path_there <- withr::local_tempdir()
+  init_quietly(path_here)
+  init_quietly(path_there)
+  suppressMessages(
+    hipercow_configure("elsewhere", path = path_there, root = path_here))
+
+  root_here <- hipercow_root(path_here)
+
+  cache$allow_load_drivers <- NULL
+  withr::defer(cache$allow_load_drivers <- NULL)
+  withr::local_envvar("HIPERCOW_NO_DRIVERS" = 1)
+
+  expect_error(
+    hipercow_driver_prepare(NULL, root_here),
+    "Trying to load a driver from code that should not do so")
+  expect_error(
+    hipercow_driver_load("elsewhere"),
+    "Trying to load a driver from code that should not do so")
+})


### PR DESCRIPTION
This is fairly nasty set of changes, despite their modest size:

1. allow preventing a driver from loading while running on the cluster (be7a136)
2. fix some bugs that made me realise that the above bug was happening (6ae953c)
3. add a workflow to allow us to install the development sources of hipercow for use on the cluster easily (035bee1, 7c7ae34)

The first one was caused by `task_status()` trying to load the windows driver on the task as it was running on windows! I've put logic in to prevent this and an assertion that will fail nice and early should it happen again. We set an environment variable in the bootstrap that will prevent driver load.

The second one was a few different small bugs:

* we don't create the job library before setting `.libPaths()` to use it (via `R_LIBS_USER`) which filters it out of the list, and then the user tries to install into the bootstrap library. Not ideal. Now we create the library when we configure the driver.
* the logging functions did not properly load the root, so failed in odd ways in real usage.

The third bit might change over time, but allows us to create a development set of bootstrap packages that we can use to make sure things work in practice. These can be selected by setting the (undocumented) global option `hipercow.development`. I'll add docs on this process to the administration vignette, once it's written