### PR TITLE
Filter out disconnected net shares

### DIFF
--- a/drivers/windows/R/mounts.R
+++ b/drivers/windows/R/mounts.R
@@ -7,7 +7,16 @@ dide_cluster_paths <- function(shares, path_root) {
     shares[[i]]$path_remote <- use_app_on_nas_south_ken(shares[[i]]$path_remote)
   }
 
+  class(shares) <- "dide_shares"
   shares
+}
+
+
+##' @export
+format.dide_shares <- function(x, ...) {
+  n <- length(x)
+  c(sprintf("%d configured:", n),
+    set_names(vcapply(x, as.character), rep(">", n)))
 }
 
 
@@ -93,12 +102,13 @@ wmic_parse <- function(x) {
   writeLines(x, tmp)
   on.exit(unlink(tmp))
   dat <- utils::read.csv(tmp, stringsAsFactors = FALSE)
-  expected <- c("RemoteName", "LocalName")
+  expected <- c("RemoteName", "LocalName", "ConnectionState")
   msg <- setdiff(expected, names(dat))
   if (length(msg) > 0) {
     stop("Failed to find expected names in wmic output: ",
          paste(msg, collapse = ", "))
   }
+  dat <- dat[dat$ConnectionState %in% "Connected", ]
   cbind(remote = dat$RemoteName, local = dat$LocalName)
 }
 

--- a/drivers/windows/R/mounts.R
+++ b/drivers/windows/R/mounts.R
@@ -7,16 +7,7 @@ dide_cluster_paths <- function(shares, path_root) {
     shares[[i]]$path_remote <- use_app_on_nas_south_ken(shares[[i]]$path_remote)
   }
 
-  class(shares) <- "dide_shares"
   shares
-}
-
-
-##' @export
-format.dide_shares <- function(x, ...) {
-  n <- length(x)
-  c(sprintf("%d configured:", n),
-    set_names(vcapply(x, as.character), rep(">", n)))
 }
 
 

--- a/drivers/windows/tests/testthat/test-mounts.R
+++ b/drivers/windows/tests/testthat/test-mounts.R
@@ -131,6 +131,18 @@ test_that("Can parse wmic output", {
 })
 
 
+test_that("Ignore disconnected mounts", {
+  x <- c("\r",
+         "Node,ConnectionState,LocalName,RemoteName,Status\r",
+         "BUILDERHV,Connected,q:,\\\\fi--san03\\homes\\bob,OK\r",
+         "BROKEN,Disconnected,T:,\\\\fi--didef3\\broken,Degraded\r")
+  expect_equal(
+    wmic_parse(x),
+    cbind(remote = c("\\\\fi--san03\\homes\\bob"),
+          local = c("q:")))
+})
+
+
 test_that("Can validate wmic output", {
   x <- c("\r",
          "node,connectionstate,localname,remotename,status\r",
@@ -200,7 +212,7 @@ test_that("wmic_call copes with command and parse errors", {
     list(
       success = FALSE,
       result = paste("Failed to find expected names in wmic output:",
-                     "RemoteName, LocalName")))
+                     "RemoteName, LocalName, ConnectionState")))
   expect_equal(
     res3,
     list(success = TRUE, result = wmic_parse(res_good)))

--- a/drivers/windows/windows.Rproj
+++ b/drivers/windows/windows.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Fix issue where windows seems to have a network share with no drive letter - which is a degraded/disconnected drive. 

This gets detected erroneously as an alternative home mountpoint, but this PR removes the problem at the source, rather than code to cope with weird results from the wmic call.