### PR TITLE
mrc-4912: Allow waiting on tasks until they start running

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.12
+Version: 0.2.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/task.R
+++ b/R/task.R
@@ -313,7 +313,7 @@ final_status_to_logical <- function(status, running_is_final = FALSE) {
 ##'   `hipercow.progress`, and if unset displays a progress bar in an
 ##'   interactive session.
 ##'
-##' @param start Logical value, indicating if we only want to wait for
+##' @param for_start Logical value, indicating if we only want to wait for
 ##'   the task to *start* rather than complete. This will block until
 ##'   the task moves away from `submitted`, and will return when it
 ##'   takes the status `running` or any terminal status (`success`,
@@ -327,7 +327,7 @@ final_status_to_logical <- function(status, running_is_final = FALSE) {
 ##'   `FALSE` otherwise.
 ##'
 ##' @export
-task_wait <- function(id, follow = TRUE, start = FALSE,
+task_wait <- function(id, follow = TRUE, for_start = FALSE,
                       timeout = Inf, poll = 1, progress = NULL, root = NULL) {
   root <- hipercow_root(root)
   if (follow) {
@@ -341,7 +341,7 @@ task_wait <- function(id, follow = TRUE, start = FALSE,
         i = "You need to submit this task to wait on it"))
   }
 
-  value <- final_status_to_logical(status, start)
+  value <- final_status_to_logical(status, for_start)
   if (is.na(value)) {
     ensure_package("logwatch")
     res <- logwatch::logwatch(
@@ -353,12 +353,12 @@ task_wait <- function(id, follow = TRUE, start = FALSE,
       poll = poll,
       timeout = timeout,
       status_waiting = "submitted",
-      status_running = if (start) character() else "running")
+      status_running = if (for_start) character() else "running")
 
     status <- res$status
-    value <- final_status_to_logical(status, start)
+    value <- final_status_to_logical(status, for_start)
     if (is.na(value)) {
-      action <- if (start) "start" else "complete"
+      action <- if (for_start) "start" else "complete"
       cli::cli_abort("Task '{id}' did not {action} in time (status: {status})")
     }
   }

--- a/R/task.R
+++ b/R/task.R
@@ -277,10 +277,10 @@ task_log_fetch <- function(id, follow, outer, root) {
 }
 
 
-final_status_to_logical <- function(status) {
+final_status_to_logical <- function(status, running_is_final = FALSE) {
   switch(status,
          submitted = NA,
-         running = NA,
+         running = if (running_is_final) TRUE else NA,
          timeout = NA, # from logwatch
          interrupt = NA, # from logwatch
          # Terminal status
@@ -292,10 +292,10 @@ final_status_to_logical <- function(status) {
 }
 
 
-##' Wait for a single task to complete.  This function is very similar
-##' to [task_log_watch], except that it errors if the job does not
-##' complete (so that it can be used easily to ensure a task has
-##' completed) and does not return any logs.
+##' Wait for a single task to complete (or to start).  This function
+##' is very similar to [task_log_watch], except that it errors if the
+##' task does not complete (so that it can be used easily to ensure a
+##' task has completed) and does not return any logs.
 ##'
 ##' The progress spinners here come from the cli package and will
 ##' respond to cli's options. In particular `cli.progress_clear` and
@@ -313,14 +313,22 @@ final_status_to_logical <- function(status) {
 ##'   `hipercow.progress`, and if unset displays a progress bar in an
 ##'   interactive session.
 ##'
+##' @param start Logical value, indicating if we only want to wait for
+##'   the task to *start* rather than complete. This will block until
+##'   the task moves away from `submitted`, and will return when it
+##'   takes the status `running` or any terminal status (`success`,
+##'   `failure`, `cancelled`). Note that this does not guarantee that
+##'   your task will still be running by the time `task_wait` exits,
+##'   your task may have finished by then!
+##'
 ##' @inheritParams logwatch::logwatch
 ##'
 ##' @return Logical value, `TRUE` if the task completed successfully,
 ##'   `FALSE` otherwise.
 ##'
 ##' @export
-task_wait <- function(id, follow = TRUE, timeout = Inf, poll = 1,
-                      progress = NULL, root = NULL) {
+task_wait <- function(id, follow = TRUE, start = FALSE,
+                      timeout = Inf, poll = 1, progress = NULL, root = NULL) {
   root <- hipercow_root(root)
   if (follow) {
     id <- follow_retry_map(id, root)
@@ -333,7 +341,7 @@ task_wait <- function(id, follow = TRUE, timeout = Inf, poll = 1,
         i = "You need to submit this task to wait on it"))
   }
 
-  value <- final_status_to_logical(status)
+  value <- final_status_to_logical(status, start)
   if (is.na(value)) {
     ensure_package("logwatch")
     res <- logwatch::logwatch(
@@ -344,12 +352,14 @@ task_wait <- function(id, follow = TRUE, timeout = Inf, poll = 1,
       show_spinner = show_progress(progress, call),
       poll = poll,
       timeout = timeout,
-      status_waiting = "submitted")
+      status_waiting = "submitted",
+      status_running = if (start) character() else "running")
 
     status <- res$status
-    value <- final_status_to_logical(status)
+    value <- final_status_to_logical(status, start)
     if (is.na(value)) {
-      cli::cli_abort("Task '{id}' did not complete in time (status: {status})")
+      action <- if (start) "start" else "complete"
+      cli::cli_abort("Task '{id}' did not {action} in time (status: {status})")
     }
   }
   value
@@ -365,7 +375,7 @@ task_wait <- function(id, follow = TRUE, timeout = Inf, poll = 1,
 ##' @inheritParams task_status
 ##'
 ##' @return A logical vector the same length as `id` indicating if the
-##'   task was cancelled. This will be `FALSE` if the job was already
+##'   task was cancelled. This will be `FALSE` if the task was already
 ##'   completed, not running, etc.
 ##'
 ##' @export

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.12
+Version: 0.2.13
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/man/task_cancel.Rd
+++ b/man/task_cancel.Rd
@@ -14,7 +14,7 @@ your directory tree.}
 }
 \value{
 A logical vector the same length as \code{id} indicating if the
-task was cancelled. This will be \code{FALSE} if the job was already
+task was cancelled. This will be \code{FALSE} if the task was already
 completed, not running, etc.
 }
 \description{

--- a/man/task_wait.Rd
+++ b/man/task_wait.Rd
@@ -7,6 +7,7 @@
 task_wait(
   id,
   follow = TRUE,
+  for_start = FALSE,
   timeout = Inf,
   poll = 1,
   progress = NULL,
@@ -18,6 +19,14 @@ task_wait(
 
 \item{follow}{Logical, indicating if we should follow any retried
 tasks.}
+
+\item{for_start}{Logical value, indicating if we only want to wait for
+the task to \emph{start} rather than complete. This will block until
+the task moves away from \code{submitted}, and will return when it
+takes the status \code{running} or any terminal status (\code{success},
+\code{failure}, \code{cancelled}). Note that this does not guarantee that
+your task will still be running by the time \code{task_wait} exits,
+your task may have finished by then!}
 
 \item{timeout}{The time to wait for the task to complete. The
 default is to wait forever.}
@@ -38,10 +47,10 @@ Logical value, \code{TRUE} if the task completed successfully,
 \code{FALSE} otherwise.
 }
 \description{
-Wait for a single task to complete.  This function is very similar
-to \link{task_log_watch}, except that it errors if the job does not
-complete (so that it can be used easily to ensure a task has
-completed) and does not return any logs.
+Wait for a single task to complete (or to start).  This function
+is very similar to \link{task_log_watch}, except that it errors if the
+task does not complete (so that it can be used easily to ensure a
+task has completed) and does not return any logs.
 }
 \details{
 The progress spinners here come from the cli package and will

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -430,6 +430,10 @@ test_that("can wait on a task, returning immediately", {
   expect_error(
     task_wait(id, root = path_here, timeout = 0, progress = FALSE),
     "Task '.+' did not complete in time")
+  expect_error(
+    task_wait(id, root = path_here, for_start = TRUE, timeout = 0,
+              progress = FALSE),
+    "Task '.+' did not start in time")
   task_eval(id, root = path_there)
   expect_true(task_wait(id, root = path_here, timeout = 0, progress = FALSE))
 })

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -253,6 +253,19 @@ test_that("can map task status to logical for task_wait", {
 })
 
 
+test_that("can map task status to logical for task_wait, running is final", {
+  expect_equal(final_status_to_logical("submitted", TRUE), NA)
+  expect_equal(final_status_to_logical("running", TRUE), TRUE)
+  expect_equal(final_status_to_logical("success", TRUE), TRUE)
+  expect_equal(final_status_to_logical("failure", TRUE), FALSE)
+  expect_equal(final_status_to_logical("cancelled", TRUE), FALSE)
+  expect_equal(final_status_to_logical("interrupt", TRUE), NA)
+  expect_equal(final_status_to_logical("timeout", TRUE), NA)
+  expect_error(final_status_to_logical("created", TRUE),
+               "Unhandled status 'created'")
+})
+
+
 test_that("check that locals are not too big", {
   expect_no_error(check_locals_size(list()))
   expect_no_error(


### PR DESCRIPTION
This generalises `task_wait` a little by allowing us to wait until a task is at least running.  This has two uses:

* I was keen to use this in a vignette to cancel a running task (rather than just one that is waiting)
* We will want this in rrq perhaps to want until tasks are running (and not until they terminate)