### PR TITLE
Be consistent about argument ordering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.13
+Version: 0.2.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/provision.R
+++ b/R/provision.R
@@ -204,5 +204,5 @@ hipercow_provision_compare <- function(curr = 0, prev = -1, driver = NULL,
   root <- hipercow_root(root)
   ensure_package("conan2", rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_compare(dat$config, root$path$root, curr, prev)
+  dat$driver$provision_compare(curr, prev, dat$config, root$path$root)
 }

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.13
+Version: 0.2.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -66,7 +66,7 @@ windows_provision_list <- function(args, config, path_root) {
 }
 
 
-windows_provision_compare <- function(config, path_root, curr, prev) {
+windows_provision_compare <- function(curr, prev, config, path_root) {
   path_lib <- file.path(path_root, config$path_lib)
   conan2::conan_compare(path_lib, curr, prev)
 }

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -92,7 +92,7 @@ test_that("camn can provision_compare using conan_compare", {
   config <- root$config$windows
   path_lib <- file.path(path_root, config$path_lib)
 
-  windows_provision_compare(config, path_root, 0, -1)
+  windows_provision_compare(0, -1, config, path_root)
   mockery::expect_called(mock_conan_compare, 1)
   expect_equal(mockery::mock_args(mock_conan_compare)[[1]],
                list(path_lib, 0, -1))

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -135,7 +135,7 @@ elsewhere_provision_run <- function(args, config, path_root) {
 
 
 
-elsewhere_provision_list <- function(method, config, path_root, args) {
+elsewhere_provision_list <- function(args, config, path_root) {
   if (is.null(args)) {
     hash <- NULL
   } else {
@@ -150,7 +150,7 @@ elsewhere_provision_list <- function(method, config, path_root, args) {
 }
 
 
-elsewhere_provision_compare <- function(config, path_root, curr, prev) {
+elsewhere_provision_compare <- function(curr, prev, config, path_root) {
   path_lib <- file.path(config$path, "hipercow", "lib")
   conan2::conan_compare(path_lib, curr, prev)
 }

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -230,7 +230,7 @@ test_that("can call provision_compare", {
   mockery::expect_called(mock_provision_compare, 1)
   expect_equal(
     mockery::mock_args(mock_provision_compare)[[1]],
-    list(config, path_root, 0, -1))
+    list(0, -1, config, path_root))
 })
 
 


### PR DESCRIPTION
Noticed this while doing #65; there is some inconsistency about argument ordering in some of the provision driver functions that needs squashing