### PR TITLE
Allow multiline expressions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.21
+Version: 0.2.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/task-create.R
+++ b/R/task-create.R
@@ -103,8 +103,9 @@ task_create_expr <- function(expr, environment = "default", submit = NULL,
   expr <- check_expression(rlang::enquo(expr))
   resources <- as_hipercow_resources(resources, root)
   envvars <- prepare_envvars(envvars, root, rlang::current_env())
-  variables <- task_variables(find_vars(expr), expr$envir, environment, root,
-                              rlang::current_env())
+  variables <- task_variables(
+    find_vars(expr$value), expr$envir, environment, root,
+    rlang::current_env())
   path <- relative_workdir(root$path$root)
   id <- task_create(root, "expression", path, environment, envvars,
                     expr = expr$value, variables = variables)

--- a/R/task-create.R
+++ b/R/task-create.R
@@ -69,7 +69,7 @@ task_create_explicit <- function(expr, export = NULL, envir = .GlobalEnv,
 ##' this behaviour is subject to change so let us know if you have
 ##' other thoughts.
 ##'
-##' Alternatively you may provide a multiline statment by using `{}`
+##' Alternatively you may provide a multiline statement by using `{}`
 ##' to surround multiple lines, such as:
 ##'
 ##' ```
@@ -84,7 +84,7 @@ task_create_explicit <- function(expr, export = NULL, envir = .GlobalEnv,
 ##'
 ##' If you reference values that require a lot of memory, `hipercow`
 ##' will error and refuse to save the task.  This is to prevent you
-##' accidentally values that you will make available through an
+##' accidentally including values that you will make available through an
 ##' environment, and to prevent making the `hipercow` directory
 ##' excessibly large.  Docs on controlling this process are still to
 ##' be written.

--- a/R/util.R
+++ b/R/util.R
@@ -330,3 +330,21 @@ special_time <- function(name, now = Sys.time()) {
   to_posix_ct(format_datetime((1900 + dt$year), (1 + dt$mon), dt$mday,
                               dt$hour, dt$min, dt$sec))
 }
+
+
+find_vars <- function(expr, exclude = character()) {
+  if (rlang::is_call(expr, "{")) {
+    ret <- character()
+    for (e in as.list(expr[-1])) {
+      if (rlang::is_call(e, c("<-", "<<-", "="))) {
+        ret <- c(ret, find_names(e[[3]], exclude))
+        exclude <- c(exclude, as.character(e[[2]]))
+      } else {
+        ret <- c(ret, find_names(e, exclude))
+      }
+    }
+    ret
+  } else {
+    setdiff(all.vars(expr), exclude)
+  }
+}

--- a/R/util.R
+++ b/R/util.R
@@ -337,10 +337,10 @@ find_vars <- function(expr, exclude = character()) {
     ret <- character()
     for (e in as.list(expr[-1])) {
       if (rlang::is_call(e, c("<-", "<<-", "="))) {
-        ret <- c(ret, find_names(e[[3]], exclude))
+        ret <- c(ret, find_vars(e[[3]], exclude))
         exclude <- c(exclude, as.character(e[[2]]))
       } else {
-        ret <- c(ret, find_names(e, exclude))
+        ret <- c(ret, find_vars(e, exclude))
       }
     }
     ret

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.21
+Version: 0.2.22
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/man/task_create_expr.Rd
+++ b/man/task_create_expr.Rd
@@ -14,7 +14,7 @@ task_create_expr(
 )
 }
 \arguments{
-\item{expr}{The expression, does not need quoting.}
+\item{expr}{The expression, does not need quoting. See Details.}
 
 \item{environment}{Name of the hipercow environment to evaluate the
 task within.}
@@ -43,4 +43,32 @@ interact with the task.
 Create a task based on an expression. This is similar to
 \link{task_create_explicit} except more magic, and is closer to
 the interface that we expect people will use.
+}
+\details{
+The expression passed as \code{expr} will typicaly be a function call
+(e.g., \code{f(x)}).  We will analyse the expression and find all
+variables that you reference (in the case of \code{f(x)} this is \code{x})
+and combine this with the function name to run on the cluster.  If
+\code{x} cannot be found in your calling environment we will error;
+this behaviour is subject to change so let us know if you have
+other thoughts.
+
+Alternatively you may provide a multiline statment by using \code{{}}
+to surround multiple lines, such as:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{task_create_expr(\{
+  x <- runif(1)
+  f(x)
+\}, ...)
+}\if{html}{\out{</div>}}
+
+in this case, we apply a simple heuristic to work out that \code{x} is
+locally assigned and should not be saved with the expression.
+
+If you reference values that require a lot of memory, \code{hipercow}
+will error and refuse to save the task.  This is to prevent you
+accidentally values that you will make available through an
+environment, and to prevent making the \code{hipercow} directory
+excessibly large.  Docs on controlling this process are still to
+be written.
 }

--- a/man/task_create_expr.Rd
+++ b/man/task_create_expr.Rd
@@ -53,7 +53,7 @@ and combine this with the function name to run on the cluster.  If
 this behaviour is subject to change so let us know if you have
 other thoughts.
 
-Alternatively you may provide a multiline statment by using \code{{}}
+Alternatively you may provide a multiline statement by using \code{{}}
 to surround multiple lines, such as:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{task_create_expr(\{
@@ -67,7 +67,7 @@ locally assigned and should not be saved with the expression.
 
 If you reference values that require a lot of memory, \code{hipercow}
 will error and refuse to save the task.  This is to prevent you
-accidentally values that you will make available through an
+accidentally including values that you will make available through an
 environment, and to prevent making the \code{hipercow} directory
 excessibly large.  Docs on controlling this process are still to
 be written.

--- a/tests/testthat/test-task-expression.R
+++ b/tests/testthat/test-task-expression.R
@@ -189,3 +189,18 @@ test_that("can validate globals on load", {
   err <- task_result(id2, root = path)
   expect_match(err$message, "Unexpected value for global variable: 'a'")
 })
+
+
+test_that("can allow more complex expressions through", {
+  path <- withr::local_tempdir()
+  init_quietly(path)
+  id <- withr::with_dir(
+    path, task_create_expr({
+      x <- 3
+      sqrt(x)
+    }))
+  env <- new.env(parent = topenv())
+  expect_true(task_eval(id, env, root = path))
+  expect_equal(env$x, 3)
+  expect_equal(task_result(id, root = path), sqrt(3))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -261,6 +261,7 @@ test_that("Duration to minutes works", {
   expect_equal(duration_to_minutes("0h0d0m"), 0)
 })
 
+
 test_that("Date formatters work", {
   expect_identical(format_datetime(2024, 1, 14, 18, 31, 0),
                    "2024-01-14 18:31:00")
@@ -322,4 +323,19 @@ test_that("Weekend special works", {
 
 test_that("Invalid special causes error", {
   expect_error(special_time("banana"), "Unrecognised special time banana")
+})
+
+
+test_that("can find names in simple expressions", {
+  expect_equal(find_names(quote(f(1))), character(0))
+  expect_equal(find_names(quote(f(x))), "x")
+  expect_setequal(find_names(quote(f(x, y, 2, z))), c("x", "y", "z"))
+  expect_equal(find_names(quote(cls$new(x))), "x")
+})
+
+
+test_that("can find names in multiline expressions with assignments", {
+  expect_equal(find_names(quote({a <- 1; f(a)})), character(0))
+  expect_equal(find_names(quote({a <- 1; f(a, x)})), "x")
+  expect_setequal(find_names(quote({a <- a + 1; f(a, x)})), c("a", "x"))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -335,7 +335,22 @@ test_that("can find names in simple expressions", {
 
 
 test_that("can find names in multiline expressions with assignments", {
-  expect_equal(find_vars(quote({a <- 1; f(a)})), character(0))
-  expect_equal(find_vars(quote({a <- 1; f(a, x)})), "x")
-  expect_setequal(find_vars(quote({a <- a + 1; f(a, x)})), c("a", "x"))
+  expect_equal(
+    find_vars(quote({
+      a <- 1
+      f(a)
+    })),
+    character(0))
+  expect_equal(
+    find_vars(quote({
+      a <- 1
+      f(a, x)
+    })),
+    "x")
+  expect_setequal(
+    find_vars(quote({
+      a <- a + 1
+      f(a, x)
+    })),
+    c("a", "x"))
 })

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -327,15 +327,15 @@ test_that("Invalid special causes error", {
 
 
 test_that("can find names in simple expressions", {
-  expect_equal(find_names(quote(f(1))), character(0))
-  expect_equal(find_names(quote(f(x))), "x")
-  expect_setequal(find_names(quote(f(x, y, 2, z))), c("x", "y", "z"))
-  expect_equal(find_names(quote(cls$new(x))), "x")
+  expect_equal(find_vars(quote(f(1))), character(0))
+  expect_equal(find_vars(quote(f(x))), "x")
+  expect_setequal(find_vars(quote(f(x, y, 2, z))), c("x", "y", "z"))
+  expect_equal(find_vars(quote(cls$new(x))), "x")
 })
 
 
 test_that("can find names in multiline expressions with assignments", {
-  expect_equal(find_names(quote({a <- 1; f(a)})), character(0))
-  expect_equal(find_names(quote({a <- 1; f(a, x)})), "x")
-  expect_setequal(find_names(quote({a <- a + 1; f(a, x)})), c("a", "x"))
+  expect_equal(find_vars(quote({a <- 1; f(a)})), character(0))
+  expect_equal(find_vars(quote({a <- 1; f(a, x)})), "x")
+  expect_setequal(find_vars(quote({a <- a + 1; f(a, x)})), c("a", "x"))
 })


### PR DESCRIPTION
This is going to be useful for implementing `rrq`/workers support, and possibly for some advanced users.  The idea is to allow multi-line expressions contained in `{}` so for example

```r
task_create_expr({
  x <- 1
  f(x)
})
```

which will run the entire expression, "returning" the last line (this is the behaviour of `local` already).  We actually supported this already, just not usefully because in this case we should exclude `x` from our list of local variables; that's the meat of this PR.