### PR TITLE
Consistent error messages for ids and bundle arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.20
+Version: 0.2.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -28,12 +28,8 @@ hipercow_bundle_create <- function(ids, name = NULL, validate = TRUE,
   if (length(ids) == 0) {
     cli::cli_abort("Can't make a bundle with no tasks")
   }
-  assert_character(ids)
-  ok <- grepl("^[[:alnum:]]{32}$", ids)
-  if (any(!ok)) {
-    cli::cli_abort(
-      "All entries in 'ids' must be valid ids (32 character hex strings)")
-  }
+  ids <- check_task_id(ids, "hipercow_bundle_create", FALSE,
+                       rlang::current_env())
   if (is.null(name)) {
     name <- ids::adjective_animal()
   } else {

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.20
+Version: 0.2.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -140,7 +140,7 @@ test_that("bundles must be composed of sensible names", {
   init_quietly(path)
   expect_error(
     hipercow_bundle_create("a", validate = FALSE, root = path),
-    "All entries in 'ids' must be valid ids (32 character hex strings)",
+    "Invalid task identifier",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -548,3 +548,48 @@ test_that("validate envvars", {
       path, task_create_expr(Sys.getenv("TEST_ENV"), envvars = TRUE)),
     "Expected a 'hipercow_envvars' object for 'envvars'")
 })
+
+
+test_that("can validate nicely that we were given incorrect inputs", {
+  b <- new_bundle("bundle", ids::random_id(3))
+
+  err <- expect_error(
+    check_task_id(b, "task_thing", FALSE, NULL),
+    "Unexpected bundle where a vector of task identifiers expected")
+  expect_equal(
+    err$body,
+    c(i = "Did you mean to pass element '$ids' of this bundle?",
+      i = "Did you mean to use 'bundle_thing()' instead of 'task_thing()'?"))
+
+  err <- expect_error(
+    check_task_id(b, "task_thing", TRUE, NULL),
+    "Unexpected bundle where a single task identifier expected")
+  expect_equal(
+    err$body,
+    c(x = paste("You have passed bundle 'bundle' to 'task_thing'",
+                "that expects a single task; this can never work"),
+      i = "Did you mean to use 'bundle_thing()' instead of 'task_thing()'?"))
+
+  err <- expect_error(
+    check_task_id(b, "thing", FALSE, NULL),
+    "Unexpected bundle where a vector of task identifiers expected")
+  expect_equal(
+    err$body,
+    c(i = "Did you mean to pass element '$ids' of this bundle?"))
+
+  err <- expect_error(
+    check_task_id("foo", "thing", FALSE, NULL),
+    "Invalid task identifier")
+  expect_equal(
+    err$body,
+    c(x = "Was given: 'foo'",
+      i = "Task identifiers are 32-character hexidecimal strings"))
+
+  err <- expect_error(
+    check_task_id(c("foo", b$ids, "bar"), "thing", FALSE, NULL),
+    "Invalid task identifiers")
+  expect_equal(
+    err$body,
+    c(x = "Was given: 'foo' and 'bar'",
+      i = "Task identifiers are 32-character hexidecimal strings"))
+})


### PR DESCRIPTION
Just a helper function that will point people in the right direction if they pass a bundle to a task function by accident