### PR TITLE
Check no running tasks before running installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.22
+Version: 0.2.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 [![R build status](https://github.com/mrc-ide/hipercow/workflows/R-CMD-check/badge.svg)](https://github.com/mrc-ide/hipercow/actions)
-[![codecov.io](https://app.codecov.io/github/mrc-ide/hipercow/coverage.svg?branch=main)](https://app.codecov.io/github/mrc-ide/hipercow?branch=main)
+[![codecov](https://codecov.io/github/mrc-ide/hipercow/graph/badge.svg?token=jeEaIEwE8P)](https://codecov.io/github/mrc-ide/hipercow)
 ![Moo](https://img.shields.io/badge/hipercow-says%20moo-pink?logo=HappyCow&logoColor=white)
 <!-- badges: end -->
 

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.22
+Version: 0.2.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -80,14 +80,15 @@ check_running_before_install <- function(client, path_root,
                                          timeout = Inf, poll = 1,
                                          progress = NULL) {
   cli::cli_alert_info("Looking for active tasks before installation")
-  res <- client$status_user(c("Running", "Queued"))
-  if (nrow(res) == 0) {
+  dat <- client$status_user("*")
+  ids <- dat$name[dat$status %in% c("submitted", "running") &
+                  grepl("^[[:xdigit:]]{32}$", dat$name)]
+  ids <- ids[file.exists(file.path(path_root, "hipercow", "tasks", ids))]
+
+  if (length(ids) == 0) {
     cli::cli_alert_success("No tasks running")
     return(TRUE)
   }
-
-  ids <- res$ids
-  ids <- ids[file.exists(file.path(path_root, "hipercow", "tasks", ids))]
   cli::cli_alert_warning(
     "You have {length(ids)} current task{?s} queued or running")
   cli::cli_alert_info(paste(

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -6,8 +6,7 @@ windows_provision_run <- function(args, config, path_root) {
   args$poll <- NULL
 
   client <- get_web_client()
-  check_running_before_install(client, timeout = Inf, poll = 1,
-                               progress = NULL, path_root = path_root)
+  check_running_before_install(client, path_root = path_root)
 
   conan_config <- rlang::inject(conan2::conan_configure(
     !!!args,
@@ -114,8 +113,9 @@ check_running_before_install <- function(client, path_root,
   if (action == "cancel") {
     cli::cli_abort("Installation cancelled, try again later")
   } else if (action == "wait") {
-    ## This requires mrc-4920
-    bundle <- hipercow_bundle_create(ids, validate = FALSE, root = path_root)
+    bundle <- hipercow::hipercow_bundle_create(ids, validate = FALSE,
+                                               root = path_root)
+    cli::cli_alert_info("Waiting for your tasks to complete")
     hipercow::hipercow_bundle_wait(bundle, timeout = timeout, poll = poll,
                                    fail_early = TRUE, progress = progress,
                                    root = path_root)

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -5,6 +5,10 @@ windows_provision_run <- function(args, config, path_root) {
   args$show_log <- NULL
   args$poll <- NULL
 
+  client <- get_web_client()
+  check_running_before_install(client, timeout = Inf, poll = 1,
+                               progress = NULL, path_root = path_root)
+
   conan_config <- rlang::inject(conan2::conan_configure(
     !!!args,
     path = path_root,
@@ -21,11 +25,11 @@ windows_provision_run <- function(args, config, path_root) {
   path_batch_unc <- windows_path_slashes(
     file.path(path_batch_dat$path_remote, path_batch_dat$rel))
 
-  client <- get_web_client()
   res <- hipercow::hipercow_resources()
   res <- hipercow::hipercow_resources_validate(res, root = path_root)
   res$queue <- list(original = "", computed = "BuildQueue")
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
+
   path_dide_id <- file.path(dirname(path_batch), DIDE_ID)
   writeLines(dide_id, path_dide_id)
 
@@ -70,4 +74,52 @@ windows_provision_list <- function(args, config, path_root) {
 windows_provision_compare <- function(curr, prev, config, path_root) {
   path_lib <- file.path(path_root, config$path_lib)
   conan2::conan_compare(path_lib, curr, prev)
+}
+
+
+check_running_before_install <- function(client, timeout, poll, progress,
+                                         path_root) {
+  cli::cli_alert_info("Looking for running tasks before installation")
+  res <- client$status_user(c("Running", "Queued"))
+  if (nrow(res) == 0) {
+    cli::cli_alert_success("No tasks running")
+    return(TRUE)
+  }
+
+  ids <- res$ids
+  ids <- ids[file.exists(file.path(path_root, "hipercow", "tasks", ids))]
+  cli::cli_alert_warning("You have {length(ids)} current task{?s} running")
+  cli::cli_alert_info(paste(
+    "Due to the way that windows handles file locking, if you install",
+    "packages while they are in use, the installation will probably fail.",
+    "Sometimes this can also leave your library in a confused state, with",
+    "partially-installed but useless packages."))
+  cli::cli_alert_info("You have three courses of action here")
+  cli::cli_li(
+    "{.strong Cancel}: Give up now and try again another time")
+  cli::cli_li(paste(
+    "{.strong Wait}: I can wait until {cli::qty(length(ids))}",
+    "{?your task has/all your tasks have} completed, then start the",
+    "installation. I won't notice though if you queue more tasks in",
+    "the meantime"))
+  cli::cli_li(paste(
+    "{.strong Install} anyway: Let's see how it goes and pick up",
+    "the pieces. Not recommended, but yolo."))
+
+  action <- readline_with_default("Action [Cancel/Wait/Install] > ")
+
+  if (action == "cancel") {
+    cli::cli_abort("Installation cancelled, try again later")
+  } else if (action == "wait") {
+    ## This requires mrc-4920
+    bundle <- hipercow_bundle_create(ids, validate = FALSE, root = path_root)
+    hipercow::hipercow_bundle_wait(bundle, timeout = timeout, poll = poll,
+                                   fail_early = TRUE, progress = progress,
+                                   root = path_root)
+    cli::cli_alert_success(
+      "All tasks now finished, proceeding with installation")
+  } else { # install
+    cli::cli_alert_warning(
+      "Trying the installation anyway, wish me luck.")
+  }
 }

--- a/drivers/windows/R/util.R
+++ b/drivers/windows/R/util.R
@@ -154,3 +154,9 @@ writelines_if_different <- function(text, path) {
 version_string <- function(v, sep = "_") {
   paste(unclass(v)[[1]], collapse = sep)
 }
+
+
+menu <- function(choices, cancel = choices[[1]]) {
+  idx <- utils::menu(choices)
+  if (idx == 0) cancel else choices[[idx]]
+}

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -151,3 +151,27 @@ test_that("can continue anyway to start if some jobs still running", {
   expect_match(res$messages[[8]],
                "Trying the installation anyway")
 })
+
+
+test_that("can wait for tasks to finish before installation", {
+  path_root <- withr::local_tempdir()
+  ids <- ids::random_id(5)
+  fs::dir_create(file.path(path_root, "hipercow", "tasks", ids[c(1, 3, 5)]))
+  mock_menu <- mockery::mock("wait")
+  mock_bundle_wait <- mockery::mock()
+
+  mockery::stub(check_running_before_install, "menu", mock_menu)
+  mockery::stub(check_running_before_install, "hipercow::hipercow_bundle_wait",
+                mock_bundle_wait)
+
+  client <- list(status_user = mockery::mock(
+                   data.frame(ids = ids)))
+
+  res <- evaluate_promise(
+    check_running_before_install(client, path_root))
+  expect_length(res$messages, 9)
+  expect_match(res$messages[[8]],
+               "Waiting for your tasks to complete")
+  expect_match(res$messages[[9]],
+               "All tasks now finished")
+})

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -107,10 +107,12 @@ test_that("camn can provision_compare using conan_compare", {
 
 test_that("can fail to start if some jobs still running", {
   path_root <- withr::local_tempdir()
+  ids <- ids::random_id(3)
+  fs::dir_create(file.path(path_root, "hipercow", "tasks", ids[c(1, 3, 5)]))
   mock_menu <- mockery::mock("cancel")
   mockery::stub(check_running_before_install, "menu", mock_menu)
   client <- list(status_user = mockery::mock(
-                   data.frame(ids = c("a", "b", "c"))))
+                   data.frame(status = "running", name = ids)))
   expect_error(
     suppressMessages(check_running_before_install(client, path_root)),
     "Installation cancelled, try again later")
@@ -120,7 +122,7 @@ test_that("can fail to start if some jobs still running", {
 
   mockery::expect_called(client$status_user, 1)
   expect_equal(mockery::mock_args(client$status_user)[[1]],
-               list(c("Running", "Queued")))
+               list("*"))
 })
 
 
@@ -132,7 +134,7 @@ test_that("can continue anyway to start if some jobs still running", {
   mock_menu <- mockery::mock("install")
   mockery::stub(check_running_before_install, "menu", mock_menu)
   client <- list(status_user = mockery::mock(
-                   data.frame(ids = ids)))
+                   data.frame(status = "running", name = ids)))
   res <- evaluate_promise(
     check_running_before_install(client, path_root))
   expect_length(res$messages, 8)
@@ -167,7 +169,7 @@ test_that("can wait for tasks to finish before installation", {
                 mock_bundle_wait)
 
   client <- list(status_user = mockery::mock(
-                   data.frame(ids = ids)))
+                   data.frame(status = "running", name = ids)))
 
   res <- evaluate_promise(
     check_running_before_install(client, path_root))

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -1,6 +1,7 @@
 test_that("can run provision script", {
   mock_client <- list(
     submit = mockery::mock("1234"),
+    status_user = mockery::mock(data.frame(ids = character())),
     status_job = mockery::mock("submitted", "running", "running", "success"))
   mock_get_client <- mockery::mock(mock_client)
   mockery::stub(windows_provision_run, "get_web_client", mock_get_client)
@@ -44,6 +45,7 @@ test_that("can run provision script", {
 test_that("error on provision script failure", {
   mock_client <- list(
     submit = mockery::mock("1234"),
+    status_user = mockery::mock(data.frame(ids = character())),
     status_job = mockery::mock("submitted", "running", "running", "failure"))
   mock_get_client <- mockery::mock(mock_client)
   mockery::stub(windows_provision_run, "get_web_client", mock_get_client)
@@ -169,9 +171,9 @@ test_that("can wait for tasks to finish before installation", {
 
   res <- evaluate_promise(
     check_running_before_install(client, path_root))
-  expect_length(res$messages, 9)
-  expect_match(res$messages[[8]],
-               "Waiting for your tasks to complete")
+  expect_length(res$messages, 10)
   expect_match(res$messages[[9]],
+               "Waiting for your tasks to complete")
+  expect_match(res$messages[[10]],
                "All tasks now finished")
 })

--- a/drivers/windows/tests/testthat/test-util.R
+++ b/drivers/windows/tests/testthat/test-util.R
@@ -135,3 +135,13 @@ test_that("writelines_if_not_exists does not update file when not different", {
   writelines_if_different(c("a", "b"), path)
   mockery::expect_called(mock_writelines, 0)
 })
+
+
+test_that("menu copes better than utils::menu with cancel", {
+  utils_menu <- mockery::mock(0, 1, 2, 3)
+  mockery::stub(menu, "utils::menu", utils_menu)
+  expect_equal(menu(c("cancel", "other", "another")), "cancel")
+  expect_equal(menu(c("cancel", "other", "another")), "cancel")
+  expect_equal(menu(c("cancel", "other", "another")), "other")
+  expect_equal(menu(c("cancel", "other", "another")), "another")
+})


### PR DESCRIPTION
Old PR, new fix.

```
library(hipercow)
hipercow_init(driver = "windows", r_version = "4.3.0")
id <- task_create_expr(Sys.sleep(10))
hipercow_provision()
```

that should be enough to play around with it.