### PR TITLE
mrc-4915: improve retry chain info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.22
+Version: 0.2.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/task-retry.R
+++ b/R/task-retry.R
@@ -107,6 +107,9 @@ retry_chain <- function(id, root) {
     id <- map$base[i]
   }
   n <- sum(map$base == id)
+  if (n == 0) {
+    return(NULL)
+  }
   ret <- rep(NA_character_, 1 + n)
   ret[[1]] <- id
   for (i in seq_len(n)) {

--- a/R/task.R
+++ b/R/task.R
@@ -487,7 +487,7 @@ task_cancel_report <- function(id, status, cancelled, eligible) {
 ##' * `status`: the retrieved status
 ##' * `driver`: the driver used to run the task (or NA)
 ##' * `times`: a vector of times
-##' * `chain`: the retry chain (or `NULL`)
+##' * `retry_chain`: the retry chain (or `NULL`)
 ##'
 ##' @export
 task_info <- function(id, follow = TRUE, root = NULL) {
@@ -529,7 +529,7 @@ task_info <- function(id, follow = TRUE, root = NULL) {
               status = status,
               driver = if (is.na(driver)) NULL else driver,
               times = times,
-              chain = retry_chain(id, root))
+              retry_chain = retry_chain(id, root))
   class(ret) <- "hipercow_task_info"
   ret
 }
@@ -540,7 +540,7 @@ print.hipercow_task_info <- function(x, ...) {
   cli::cli_h1("task {x$id} ({x$status})")
   print_info_driver(x$driver)
   print_info_times(x$times, x$status)
-  print_info_retry_chain(x$id, x$chain)
+  print_info_retry_chain(x$id, x$retry_chain)
   invisible(x)
 }
 

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.22
+Version: 0.2.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-task-retry.R
+++ b/tests/testthat/test-task-retry.R
@@ -113,8 +113,8 @@ test_that("can retry a retried task", {
   expect_equal(retry_chain(id3, root = root), c(id1, id2, id3, id4))
   expect_equal(retry_chain(id4, root = root), c(id1, id2, id3, id4))
 
-  expect_equal(task_info(id1, root = path)$chain, c(id1, id2, id3, id4))
-  expect_equal(task_info(id4, root = path)$chain, c(id1, id2, id3, id4))
+  expect_equal(task_info(id1, root = path)$retry_chain, c(id1, id2, id3, id4))
+  expect_equal(task_info(id4, root = path)$retry_chain, c(id1, id2, id3, id4))
 })
 
 
@@ -168,6 +168,6 @@ test_that("don't add retry element when not wanted", {
   r1 <- task_result(id1, root = path)
   id2 <- task_retry(id1, root = path)
   id3 <- withr::with_dir(path, task_create_explicit(quote(runif(1))))
-  expect_equal(task_info(id1, root = path)$chain, c(id1, id2))
-  expect_null(task_info(id3, root = path)$chain)
+  expect_equal(task_info(id1, root = path)$retry_chain, c(id1, id2))
+  expect_null(task_info(id3, root = path)$retry_chain)
 })

--- a/tests/testthat/test-task-retry.R
+++ b/tests/testthat/test-task-retry.R
@@ -158,3 +158,16 @@ test_that("can choose to follow logs or not", {
   expect_equal(task_log_value(id1, follow = FALSE, root = path_here), "a")
   expect_equal(task_log_value(id2, follow = FALSE, root = path_here), "b")
 })
+
+
+test_that("don't add retry element when not wanted", {
+  path <- withr::local_tempdir()
+  init_quietly(path)
+  id1 <- withr::with_dir(path, task_create_explicit(quote(runif(1))))
+  expect_true(task_eval(id1, root = path))
+  r1 <- task_result(id1, root = path)
+  id2 <- task_retry(id1, root = path)
+  id3 <- withr::with_dir(path, task_create_explicit(quote(runif(1))))
+  expect_equal(task_info(id1, root = path)$chain, c(id1, id2))
+  expect_null(task_info(id3, root = path)$chain)
+})

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -372,7 +372,7 @@ test_that("can get info from successful task", {
   expect_null(info$driver)
   expect_s3_class(info$times, "POSIXct")
   expect_equal(names(info$times), c("created", "started", "finished"))
-  expect_null(info$chain)
+  expect_null(info$retry_chain)
   msg <- capture_messages(print(info))
   ## Specific tests for this below
   expect_match(msg, sprintf("task %s (success)", id), fixed = TRUE, all = FALSE)
@@ -395,7 +395,7 @@ test_that("can get info from created task", {
   expect_equal(names(info$times), c("created", "started", "finished"))
   expect_equal(is.na(info$times),
                c(created = FALSE, started = TRUE, finished = TRUE))
-  expect_null(info$chain)
+  expect_null(info$retry_chain)
 })
 
 
@@ -411,7 +411,7 @@ test_that("can get info from successful task", {
   expect_null(info$driver)
   expect_s3_class(info$times, "POSIXct")
   expect_equal(names(info$times), c("created", "started", "finished"))
-  expect_null(info$chain)
+  expect_null(info$retry_chain)
 })
 
 
@@ -504,23 +504,23 @@ test_that("can print information about the chain in info", {
          status = "created",
          driver = NULL,
          times = c(created = Sys.time(), started = NA, finished = NA),
-         chain = c("aaa", "bbb", "ccc")),
+         retry_chain = c("aaa", "bbb", "ccc")),
     class = "hipercow_task_info")
   msg <- capture_messages(print(info))
-  cmp <- capture_messages(print_info_retry_chain(info$id, info$chain))
+  cmp <- capture_messages(print_info_retry_chain(info$id, info$retry_chain))
   expect_match(msg, cmp, fixed = TRUE, all = FALSE)
 
   expect_message(
-    print_info_retry_chain("aaa", info$chain),
+    print_info_retry_chain("aaa", info$retry_chain),
     "1st of a chain of a task retried 2 times, most recently 'ccc'")
   expect_message(
-    print_info_retry_chain("aaa", info$chain[-3]),
+    print_info_retry_chain("aaa", info$retry_chain[-3]),
     "1st of a chain of a task retried 1 time, most recently 'bbb'")
   expect_message(
-    print_info_retry_chain("ccc", info$chain),
+    print_info_retry_chain("ccc", info$retry_chain),
     "Last of a chain of a task retried 2 times")
   expect_message(
-    print_info_retry_chain("bbb", info$chain[-3]),
+    print_info_retry_chain("bbb", info$retry_chain[-3]),
     "Last of a chain of a task retried 1 time")
 })
 

--- a/vignettes/hipercow.Rmd
+++ b/vignettes/hipercow.Rmd
@@ -547,7 +547,7 @@ You can see the full chain of retries here:
 
 
 ```r
-task_info(id2)$chain
+task_info(id2)$retry_chain
 #> [1] "d0b24110611a4da47c20174492515f64" "ac5dc5ba443e9c4212161766f7cfe344"
 ```
 

--- a/vignettes_src/hipercow.Rmd
+++ b/vignettes_src/hipercow.Rmd
@@ -347,7 +347,7 @@ task_info(id2)
 You can see the full chain of retries here:
 
 ```{r}
-task_info(id2)$chain
+task_info(id2)$retry_chain
 ```
 
 Once a task has been retried it affects how you interact with the previous ids; by default they follow through to the most recent element in the chain:


### PR DESCRIPTION
This PR renames the field in the task info that retry chain information is saved in, and removes the odd addition of a "zero length chain" retry that was saved only once _any_ retries had been made