### PR TITLE
Avoid accidentally finding the package root

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.34
+Version: 0.2.35
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports:
     fs,
     ids,
     rlang,
-    rprojroot,
     withr
 Suggests:
     callr,

--- a/R/root.R
+++ b/R/root.R
@@ -59,7 +59,7 @@ hipercow_root <- function(root = NULL) {
   if (inherits(root, "hipercow_root")) {
     return(root)
   }
-  path <- hipercow_root_find(root)
+  path <- hipercow_root_find(root %||% getwd())
   if (is.null(cache$roots[[path]])) {
     ret <- new.env(parent = emptyenv())
     ret$path <- list(
@@ -91,6 +91,18 @@ hipercow_root <- function(root = NULL) {
 
 
 hipercow_root_find <- function(path) {
-  path <- rprojroot::find_root(rprojroot::has_dir("hipercow"), path %||% ".")
+  path <- find_directory_descend("hipercow", start = path, limit = "/")
+  path_description <- file.path(path, "DESCRIPTION")
+  if (file.exists(path_description)) {
+    d <- as.list(read.dcf(path_description)[1, ])
+    if (identical(d$Package, "hipercow")) {
+      cli::cli_abort(
+        c("Found unlikely hipercow root",
+          i = paste("Hi Rich or Wes. It looks like you forgot to add an",
+                    "argument 'root = path' to whatever you're writing at the",
+                    "moment."),
+          i = "(If you're someone else seeing this, we're curious how)"))
+    }
+  }
   normalize_path(path)
 }

--- a/R/util.R
+++ b/R/util.R
@@ -372,3 +372,28 @@ find_vars <- function(expr, exclude = character()) {
 readlines_if_exists <- function(path) {
   if (file.exists(path)) readLines(path) else NULL
 }
+
+
+find_directory_descend <- function(target, start = ".", limit = "/") {
+  root <- normalize_path(limit)
+  start <- normalize_path(start)
+
+  f <- function(path) {
+    if (dir.exists(file.path(path, target))) {
+      return(path)
+    }
+    if (normalize_path(path) == root) {
+      return(NULL)
+    }
+    parent <- normalize_path(file.path(path, ".."))
+    if (parent == path) {
+      return(NULL)
+    }
+    f(parent)
+  }
+  ret <- f(start)
+  if (!(is.null(ret))) {
+    ret <- normalize_path(ret)
+  }
+  ret
+}

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.34
+Version: 0.2.35
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -34,6 +34,18 @@ test_that("Can locate a hipercow root from a subdirectory", {
 })
 
 
+test_that("avoid finding the hipercow package by default", {
+  path <- withr::local_tempdir()
+  path_pkg <- file.path(path, "hipercow")
+  fs::dir_create(path_pkg)
+  writeLines("Package: hipercow", file.path(path, "DESCRIPTION"))
+  path_tests <- file.path(path_pkg, "tests/testthat")
+  fs::dir_create(path_tests)
+  expect_error(hipercow_root_find(path_tests),
+               "Found unlikely hipercow root")
+})
+
+
 test_that("Error if root not found", {
   path <- withr::local_tempdir()
   expect_error(hipercow_root(path))

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -393,3 +393,27 @@ test_that("readlines_if_exists returns NULL if file missing", {
   writeLines(letters, tmp)
   expect_equal(readlines_if_exists(tmp), letters)
 })
+
+
+test_that("Descend failure", {
+  path <- withr::local_tempdir()
+  path <- normalize_path(path)
+  expect_null(find_directory_descend("foo", tempdir(), path))
+  expect_null(find_directory_descend("foo", "/", path))
+  expect_null(find_directory_descend("foo", "/", "/"))
+})
+
+
+test_that("Descend success", {
+  path <- withr::local_tempdir()
+  path <- normalize_path(path)
+  fs::dir_create(file.path(path, "foo"))
+  fs::dir_create(file.path(path, "a/b/c"))
+
+  expect_equal(find_directory_descend("foo", path, "/"),
+               path)
+  expect_equal(find_directory_descend("foo", file.path(path, "a"), "/"),
+               path)
+  expect_equal(find_directory_descend("foo", file.path(path, "a/b/c"), "/"),
+               path)
+})


### PR DESCRIPTION
This PR stops me accidentally finding the hipercow *package* root when writing tests, when what I am expecting to find is the root that we are writing tests against.

I've also dropped rprojroot because it's not buying us here, and just pulled in the same code as in orderly/orderly2 that has served well over the years