### PR TITLE
mrc-4951: harmonise errors from resource checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.35
+Version: 0.2.36
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/resource.R
+++ b/R/resource.R
@@ -137,6 +137,11 @@ validate_max_runtime <- function(max_runtime, call = NULL) {
 
 }
 
+## Special hold until values that will be computed only at the point
+## of submission
+hold_until_special <- c("tonight", "midnight", "weekend")
+
+
 validate_hold_until <- function(hold_until, call = NULL) {
   if (is.null(hold_until)) {
     return(list(original = NULL, computed = NULL))
@@ -150,7 +155,7 @@ validate_hold_until <- function(hold_until, call = NULL) {
                        x = "{hold_until} is in the past"),
                      arg = "hold_until", call = call)
     }
-  } else if (hold_until %in% c("tonight", "midnight")) {
+  } else if (hold_until %in% hold_until_special) {
     computed <- hold_until
   } else {
     computed <- duration_to_minutes(hold_until, "hold_until")

--- a/R/resource.R
+++ b/R/resource.R
@@ -174,8 +174,8 @@ validate_memory <- function(value, name, call = NULL) {
   if (is.numeric(value)) {
     if (!rlang::is_integerish(value) || is.na(value) || value < 0) {
       cli::cli_abort(
-        c("Invalid value for '{name}': {cores}",
-          i = "Number of cores must be a positive integer, or 'Inf'"),
+        c("Invalid value for '{name}': {value}",
+          i = "Amount of memory must be a positive integer"),
         call = call, arg = name)
     }
     computed <- value
@@ -193,16 +193,17 @@ validate_memory <- function(value, name, call = NULL) {
     if (sub(re, "\\2", value) == "T") {
       computed <- computed * 1000
     }
-    if (computed == 0) {
-      cli::cli_abort(
-        c("Invalid value for '{name}': {cores}",
-          i = "We need some memory to run your tasks!"),
-        call = call, arg = name)
-    }
   } else {
     cli::cli_abort(
-      c("Invalid value for '{name}': {cores}",
+      c("Invalid value for '{name}': {value}",
         i = "Expected an integer or a string representing a size"),
+      call = call, arg = name)
+  }
+
+  if (computed == 0) {
+    cli::cli_abort(
+      c("Invalid value for '{name}': {value}",
+        i = "We need some memory to run your tasks!"),
       call = call, arg = name)
   }
 

--- a/R/submit.R
+++ b/R/submit.R
@@ -29,7 +29,7 @@ task_submit <- function(id, ..., resources = NULL,
   resources <- resources_validate(resources, driver, root)
   dat <- hipercow_driver_prepare(driver, root, environment())
   set_special_time <- !is.null(resources$hold_until$computed) &&
-    resources$hold_until$computed %in% c("tonight", "midnight", "weekend")
+    resources$hold_until$computed %in% hold_until_special
   if (set_special_time) {
     resources$hold_until$computed <- special_time(resources$hold_until$computed)
   }

--- a/R/util.R
+++ b/R/util.R
@@ -281,7 +281,7 @@ duration_to_minutes <- function(period, name = "testing", call = NULL) {
       fail_msg("'{name}' is a negative number of minutes")
     }
     if (period == 0) {
-      fail_msg("{name}' is a zero minutes")
+      fail_msg("{name}' is zero minutes")
     }
     ret <- as.integer(period)
   } else if (is.character(period)) {

--- a/R/util.R
+++ b/R/util.R
@@ -280,28 +280,36 @@ duration_to_minutes <- function(period, name = "testing", call = NULL) {
     if (period < 0) {
       fail_msg("'{name}' is a negative number of minutes")
     }
-    return(as.integer(period))
-  }
+    if (period == 0) {
+      fail_msg("{name}' is a zero minutes")
+    }
+    ret <- as.integer(period)
+  } else if (is.character(period)) {
+    ## Easy case; we were given a string integer
+    if (grepl("^[0-9]+$", period)) {
+      ret <- as.integer(period)
+    } else {
+      re <- "^(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?$"
+      if (!grepl(re, period, ignore.case = TRUE)) {
+        fail_msg("Failed to parse string into XhYdZm format")
+      }
 
-  if (!is.character(period)) {
+      d <- as.integer(sub(re, "\\2", period, ignore.case = TRUE)) * 1440
+      h <- as.integer(sub(re, "\\4", period, ignore.case = TRUE)) * 60
+      m <- as.integer(sub(re, "\\6", period, ignore.case = TRUE))
+
+      ret <- (if (is.na(d)) 0 else d) +
+        (if (is.na(h)) 0 else h) +
+        (if (is.na(m)) 0 else m)
+    }
+  } else {
     fail_msg("'{name}' must be a number or a string representing a duration")
   }
 
-  ## Easy case; we were given a string integer
-  if (grepl("^[0-9]+$", period)) {
-    return(as.integer(period))
+  if (ret == 0) {
+    fail_msg("{name}' is zero minutes")
   }
-
-  re <- "^(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?$"
-  if (!grepl(re, period)) {
-    fail_msg("Failed to parse string into XhYdZm format")
-  }
-
-  d <- as.integer(sub(re, "\\2", period)) * 1440
-  h <- as.integer(sub(re, "\\4", period)) * 60
-  m <- as.integer(sub(re, "\\6", period))
-
-  (if (is.na(d)) 0 else d) + (if (is.na(h)) 0 else h) + (if (is.na(m)) 0 else m)
+  ret
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -307,7 +307,7 @@ duration_to_minutes <- function(period, name = "testing", call = NULL) {
   }
 
   if (ret == 0) {
-    fail_msg("{name}' is zero minutes")
+    fail_msg("'{name}' is zero minutes")
   }
   ret
 }

--- a/R/util.R
+++ b/R/util.R
@@ -330,7 +330,7 @@ special_time_tonight <- function(now = Sys.time()) {
   dt$hour <- 19
   dt$min <- 0
   dt$sec <- 0
-  as_time(dt)
+  as_time(dt, attr(now, "tzone") %||% "")
 }
 
 special_time_midnight <- function(now = Sys.time()) {
@@ -338,7 +338,7 @@ special_time_midnight <- function(now = Sys.time()) {
   if (dt$hour < 3) {
     return(now) # or NULL?
   }
-  as_time(as.Date(now) + 1)
+  as_time(as.Date(now) + 1, attr(now, "tzone") %||% "")
 }
 
 
@@ -347,7 +347,7 @@ special_time_weekend <- function(now = Sys.time()) {
   if (dt$wday %in% c(0, 6)) { # Americans, smh
     return(now)
   }
-  as_time(as.Date(now) + (6 - dt$wday))
+  as_time(as.Date(now) + (6 - dt$wday), attr(now, "tzone") %||% "")
 }
 
 

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.35
+Version: 0.2.36
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/tests/testthat/test-web.R
+++ b/drivers/windows/tests/testthat/test-web.R
@@ -269,7 +269,7 @@ test_that("submit sends correct payload", {
 
 test_that("hipercow_resources processed into web api call", {
   res <- hipercow::hipercow_resources(
-    hold_until = "2m", queue = "AllNodes", max_runtime = "2h30",
+    hold_until = "2m", queue = "AllNodes", max_runtime = "2h30m",
     priority = "low", memory_per_node = "32G", memory_per_process = "1G",
     requested_nodes = c("wpia-063", "wpia-065"),
     exclusive = TRUE, cores = Inf)

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -193,8 +193,3 @@ elsewhere_cluster_info <- function(config, path_root) {
   r_versions <- getRversion()
   list(resources = resources, r_versions = r_versions, redis_url = redis_url)
 }
-
-
-resource_test <- function(f, v, comp = v) {
-  expect_identical(f(v), list(original = v, computed = comp))
-}

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -2,15 +2,15 @@ test_that("Validate resource args", {
   resource_test(validate_cores, Inf)
   resource_test(validate_cores, 1, 1L)
   expect_error(validate_cores(-Inf),
-               "Could not understand number of cores '-Inf'")
+               "Invalid value for 'cores': -Inf")
   expect_error(validate_cores(-1),
-               "Could not understand number of cores '-1'")
+               "Invalid value for 'cores': -1")
   expect_error(validate_cores("potato"),
-               "Could not understand number of cores 'potato'")
+               "Invalid value for 'cores': potato")
   expect_error(validate_cores(NULL),
                "'cores' must be a scalar")
   expect_error(validate_cores(NA),
-               "Could not understand number of cores 'NA'")
+               "Invalid value for 'cores': NA")
   expect_error(validate_cores(mtcars),
                "'cores' must be a scalar")
   expect_error(validate_cores(c(1, 2, 3)),
@@ -21,8 +21,12 @@ test_that("Validate resource args", {
 test_that("validate max_runtime", {
   resource_test(validate_max_runtime, NULL)
   resource_test(validate_max_runtime, 35)
-  expect_error(validate_max_runtime("0"))
-  expect_error(validate_max_runtime("Kazahstan"))
+  expect_error(
+    validate_max_runtime("0"),
+    "Invalid value for 'max_runtime': 0")
+  expect_error(
+    validate_max_runtime("Kazahstan"),
+    "Invalid value for 'max_runtime': 0")
   expect_error(validate_max_runtime(NA))
   expect_error(validate_max_runtime(c(1, 2, 3)))
   expect_error(validate_max_runtime("0d0d"))

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -96,6 +96,24 @@ test_that("validate memory", {
                "Invalid string representation of memory for 'mem': 1G2T")
   expect_error(validate_memory("1GG", "mem"),
                "Invalid string representation of memory for 'mem': 1GG")
+
+  err <- expect_error(validate_memory(-1, "mem"),
+                      "Invalid value for 'mem': -1")
+  expect_equal(err$body,
+               c(i = "Amount of memory must be a positive integer"))
+
+  err <- expect_error(validate_memory(TRUE, "mem"),
+                      "Invalid value for 'mem': TRUE")
+  expect_equal(
+    err$body,
+    c(i = "Expected an integer or a string representing a size"))
+
+
+  err <- expect_error(validate_memory(0, "mem"),
+                      "Invalid value for 'mem': 0")
+  expect_equal(
+    err$body,
+    c(i = "We need some memory to run your tasks!"))
 })
 
 

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -26,7 +26,7 @@ test_that("validate max_runtime", {
                list(original = 35, computed = 35))
   expect_equal(validate_max_runtime("2h35m"),
                list(original = "2h35m", computed = 155))
-  
+
   expect_error(
     validate_max_runtime("0"),
     "Invalid value for 'max_runtime': 0")
@@ -65,7 +65,7 @@ test_that("validate hold_until", {
   today <- Sys.Date()
   expect_error(validate_hold_until(today),
                "Invalid value for 'hold_until'")
-  
+
   soon <- Sys.time() + 120
   expect_equal(validate_hold_until(soon),
                list(original = soon, computed = as.POSIXlt(soon)))

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -76,32 +76,50 @@ test_that("validate hold_until", {
 
 
 test_that("validate memory", {
-  resource_test(validate_memory, NULL)
-  expect_error(validate_memory(c("a", "b")))
-  expect_error(validate_memory("10M"))
-  resource_test(validate_memory, 1)
-  resource_test(validate_memory, "1", 1)
-  resource_test(validate_memory, "9G", 9)
-  resource_test(validate_memory, "2T", 2000)
-  expect_error(validate_memory("1G2T"))
-  expect_error(validate_memory("1GG"))
+  expect_equal(validate_memory(NULL, "mem"),
+               list(original = NULL, computed = NULL))
+  expect_error(
+    validate_memory(c("a", "b"), "mem"),
+    "'mem' must be a scalar")
+  expect_error(
+    validate_memory("10M", "mem"),
+    "Invalid string representation of memory for 'mem': 10M")
+  expect_equal(validate_memory(1, "mem"),
+               list(original = 1, computed = 1))
+  expect_equal(validate_memory("1", "mem"),
+               list(original = "1", computed = 1))
+  expect_equal(validate_memory("9G", "mem"),
+               list(original = "9G", computed = 9))
+  expect_equal(validate_memory("2T", "mem"),
+               list(original = "2T", computed = 2000))
+  expect_error(validate_memory("1G2T", "mem"),
+               "Invalid string representation of memory for 'mem': 1G2T")
+  expect_error(validate_memory("1GG", "mem"),
+               "Invalid string representation of memory for 'mem': 1GG")
 })
 
 
 test_that("validate nodes", {
-  resource_test(validate_nodes, NULL)
-  expect_error(validate_nodes(NA))
-  resource_test(validate_nodes, c("A", "B"))
-  resource_test(validate_nodes, "A")
-  resource_test(validate_nodes, c("A", "A"), "A")
+  expect_equal(validate_nodes(NULL), list(original = NULL, computed = NULL))
+  expect_equal(validate_nodes(c("A", "B")),
+               list(original = c("A", "B"), computed = c("A", "B")))
+  expect_equal(validate_nodes(c("A", "A")),
+               list(original = c("A", "A"), computed = "A"))
+  expect_equal(validate_nodes("A"),
+               list(original = "A", computed = "A"))
+  expect_error(validate_nodes(NA),
+               "'nodes' must be a character")
 })
 
 
 test_that("validate priority", {
-  resource_test(validate_priority, NULL)
-  resource_test(validate_priority, "low")
-  resource_test(validate_priority, "normal")
-  expect_error(validate_priority(3000))
+  expect_equal(validate_priority(NULL), list(original = NULL, computed = NULL))
+  expect_equal(validate_priority("low"),
+               list(original = "low", computed = "low"))
+  expect_equal(validate_priority("normal"),
+               list(original = "normal", computed = "normal"))
+  expect_error(validate_priority(3000),
+               "'priority' must be a character")
 })
 
 
@@ -119,10 +137,12 @@ test_that("prevent high priorities", {
 
 
 test_that("validate queue", {
-  resource_test(validate_queue, NULL)
-  expect_error(validate_queue(NA))
-  expect_error(validate_queue(c("a", "b")))
-  resource_test(validate_queue, "Q")
+  expect_equal(validate_queue(NULL), list(original = NULL, computed = NULL))
+  expect_equal(validate_queue("Q"), list(original = "Q", computed = "Q"))
+  expect_error(validate_queue(NA),
+               "'queue' must be a character")
+  expect_error(validate_queue(c("a", "b")),
+               "'queue' must be a scalar")
 })
 
 

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -1,6 +1,7 @@
 test_that("Validate resource args", {
-  resource_test(validate_cores, Inf)
-  resource_test(validate_cores, 1, 1L)
+  expect_equal(validate_cores(Inf), list(original = Inf, computed = Inf))
+  expect_equal(validate_cores(1), list(original = 1, computed = 1L))
+
   expect_error(validate_cores(-Inf),
                "Invalid value for 'cores': -Inf")
   expect_error(validate_cores(-1),
@@ -19,35 +20,60 @@ test_that("Validate resource args", {
 
 
 test_that("validate max_runtime", {
-  resource_test(validate_max_runtime, NULL)
-  resource_test(validate_max_runtime, 35)
+  expect_equal(validate_max_runtime(NULL),
+               list(original = NULL, computed = NULL))
+  expect_equal(validate_max_runtime(35),
+               list(original = 35, computed = 35))
+  expect_equal(validate_max_runtime("2h35m"),
+               list(original = "2h35m", computed = 155))
+  
   expect_error(
     validate_max_runtime("0"),
     "Invalid value for 'max_runtime': 0")
   expect_error(
     validate_max_runtime("Kazahstan"),
-    "Invalid value for 'max_runtime': 0")
-  expect_error(validate_max_runtime(NA))
-  expect_error(validate_max_runtime(c(1, 2, 3)))
-  expect_error(validate_max_runtime("0d0d"))
+    "Invalid value for 'max_runtime': Kazahstan")
+  expect_error(
+    validate_max_runtime(NA),
+    "Invalid value for 'max_runtime': NA")
+  expect_error(
+    validate_max_runtime(c(1, 2, 3)),
+    "'max_runtime' must be a scalar")
 })
 
 
 test_that("validate hold_until", {
-  resource_test(validate_hold_until, NULL)
-  resource_test(validate_hold_until, "tonight")
-  resource_test(validate_hold_until, "midnight")
-  expect_error(validate_hold_until(0))
-  resource_test(validate_hold_until, 60)
-  resource_test(validate_hold_until, "2h30", 150)
-  resource_test(validate_hold_until, "1d1h1m", 1501)
-  resource_test(validate_hold_until, Sys.Date() + 1,
-                                     as.POSIXlt(Sys.Date() + 1))
-  expect_error(validate_hold_until(Sys.Date()))
-  now <- Sys.time()
-  resource_test(validate_hold_until, now + 120, now + 120)
-  expect_error(validate_hold_until(now - 1))
+  expect_equal(validate_hold_until(NULL),
+               list(original = NULL, computed = NULL))
+  expect_equal(validate_hold_until("tonight"),
+               list(original = "tonight", computed = "tonight"))
+  expect_equal(validate_hold_until("midnight"),
+               list(original = "midnight", computed = "midnight"))
+
+  expect_error(
+    validate_hold_until(0),
+    "Invalid value for 'hold_until': 0")
+  expect_equal(validate_hold_until(60),
+               list(original = 60, computed = 60))
+  expect_equal(validate_hold_until("2h30m"),
+               list(original = "2h30m", computed = 150))
+  expect_equal(validate_hold_until("1d1h1m"),
+               list(original = "1d1h1m", computed = 1501))
+  tomorrow <- Sys.Date() + 1
+  expect_equal(validate_hold_until(tomorrow),
+               list(original = tomorrow, computed = as.POSIXlt(tomorrow)))
+  today <- Sys.Date()
+  expect_error(validate_hold_until(today),
+               "Invalid value for 'hold_until'")
+  
+  soon <- Sys.time() + 120
+  expect_equal(validate_hold_until(soon),
+               list(original = soon, computed = as.POSIXlt(soon)))
+  err <- expect_error(validate_hold_until(Sys.time() - 1),
+                      "Invalid value for 'hold_until'")
+  expect_match(err$body[[1]], "is in the past")
 })
+
 
 test_that("validate memory", {
   resource_test(validate_memory, NULL)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -295,64 +295,56 @@ test_that("report failure in duration to minutes nicely", {
 })
 
 
-test_that("Date formatters work", {
-  expect_identical(format_datetime(2024, 1, 14, 18, 31, 0),
-                   "2024-01-14 18:31:00")
-  expect_identical(to_posix_ct(format_datetime(2024, 1, 14, 18, 31, 0)),
-                   as.POSIXct("2024-01-14 18:31:00"))
-
-})
-
 test_that("Tonight special works", {
-  now <- as.POSIXct("2024-01-14 18:31:00")
+  now <- as_time("2024-01-14 18:31:00")
   ton <- special_time("tonight", now)
-  expect_identical(ton, as.POSIXct("2024-01-14 19:00:00"))
+  expect_identical(ton, as_time("2024-01-14 19:00:00"))
 
-  now <- as.POSIXct("2024-01-15 02:59:00")
+  now <- as_time("2024-01-15 02:59:00")
   ton <- special_time("tonight", now)
-  expect_identical(ton, as.POSIXct("2024-01-15 02:59:00"))
+  expect_identical(ton, as_time("2024-01-15 02:59:00"))
 
-  now <- as.POSIXct("2024-01-15 03:00:00")
+  now <- as_time("2024-01-15 03:00:00")
   ton <- special_time("tonight", now)
-  expect_identical(ton, as.POSIXct("2024-01-15 19:00:00"))
+  expect_identical(ton, as_time("2024-01-15 19:00:00"))
 })
 
 test_that("Midnight special works", {
-  now <- as.POSIXct("2024-01-14 18:31:00")
+  now <- as_time("2024-01-14 18:31:00")
   ton <- special_time("midnight", now)
-  expect_identical(ton, as.POSIXct("2024-01-15 00:00:00"))
+  expect_identical(ton, as_time("2024-01-15 00:00:00"))
 
-  now <- as.POSIXct("2024-01-15 02:59:00")
+  now <- as_time("2024-01-15 02:59:00")
   ton <- special_time("midnight", now)
-  expect_identical(ton, as.POSIXct("2024-01-15 02:59:00"))
+  expect_identical(ton, as_time("2024-01-15 02:59:00"))
 
-  now <- as.POSIXct("2024-01-15 03:00:00")
+  now <- as_time("2024-01-15 03:00:00")
   ton <- special_time("midnight", now)
-  expect_identical(ton, as.POSIXct("2024-01-16 00:00:00"))
+  expect_identical(ton, as_time("2024-01-16 00:00:00"))
 })
 
 test_that("Weekend special works", {
   # Friday night - run at midnight Sat.
-  now <- as.POSIXct("2024-01-12 18:31:00")
+  now <- as_time("2024-01-12 18:31:00")
   ton <- special_time("weekend", now)
-  expect_identical(ton, as.POSIXct("2024-01-13 00:00:00"))
+  expect_identical(ton, as_time("2024-01-13 00:00:00"))
 
   # Still Sat. You can run now.
-  now <- as.POSIXct("2024-01-13 18:31:00")
+  now <- as_time("2024-01-13 18:31:00")
   ton <- special_time("weekend", now)
-  expect_identical(ton, as.POSIXct("2024-01-13 18:31:00"))
+  expect_identical(ton, as_time("2024-01-13 18:31:00"))
 
   # Sunday after 6pm... ok...
-  now <- as.POSIXct("2024-01-14 18:31:00")
+  now <- as_time("2024-01-14 18:31:00")
   ton <- special_time("weekend", now)
-  expect_identical(ton, as.POSIXct("2024-01-14 18:31:00"))
+  expect_identical(ton, as_time("2024-01-14 18:31:00"))
 
   # Monday. Wait til the weekend
-  now <- as.POSIXct("2024-01-15 18:31:00")
+  now <- as_time("2024-01-15 18:31:00")
   ton <- special_time("weekend", now)
-  expect_identical(ton, as.POSIXct("2024-01-20 00:00:00"))
-
+  expect_identical(ton, as_time("2024-01-20 00:00:00"))
 })
+
 
 test_that("Invalid special causes error", {
   expect_error(special_time("banana"), "Unrecognised special time banana")

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -257,20 +257,40 @@ test_that("Duration to minutes works", {
   expect_equal(duration_to_minutes(35), 35)
   expect_equal(duration_to_minutes("35"), 35)
   expect_equal(duration_to_minutes("1h"), 60)
-  expect_equal(duration_to_minutes("1h1"), 61)
+  expect_equal(duration_to_minutes("1h1m"), 61)
   expect_equal(duration_to_minutes("1h2m"), 62)
   expect_equal(duration_to_minutes("3h0m"), 180)
-  expect_equal(duration_to_minutes("3h1d"), 1620)
+  expect_equal(duration_to_minutes("1d3h"), 1620)
   expect_equal(duration_to_minutes("2d"), 2880)
   expect_equal(duration_to_minutes("13h"), 780)
   expect_equal(duration_to_minutes("40d"), 57600)
-  expect_equal(duration_to_minutes("11d22m33h"), 17842)
+  expect_equal(duration_to_minutes("11d33h22m"), 17842)
   expect_equal(duration_to_minutes("0"), 0)
   expect_equal(duration_to_minutes("0d"), 0)
   expect_equal(duration_to_minutes("0h"), 0)
   expect_equal(duration_to_minutes("0m"), 0)
   expect_equal(duration_to_minutes("0d0m"), 0)
-  expect_equal(duration_to_minutes("0h0d0m"), 0)
+  expect_equal(duration_to_minutes("0d0h0m"), 0)
+})
+
+
+test_that("report failure in duration to minutes nicely", {
+  err <- expect_error(duration_to_minutes("tonight"),
+                      "Invalid value for 'testing': tonight")
+  expect_equal(err$body[[1]], "Failed to parse string into XhYdZm format")
+
+  err <- expect_error(duration_to_minutes(pi),
+                      "Invalid value for 'testing': 3.141")
+  expect_equal(err$body[[1]], "'testing' is a non-integer number of minutes")
+
+  err <- expect_error(duration_to_minutes(-5),
+                      "Invalid value for 'testing': -5")
+  expect_equal(err$body[[1]], "'testing' is a negative number of minutes")
+
+  err <- expect_error(duration_to_minutes(TRUE),
+                      "Invalid value for 'testing': TRUE")
+  expect_equal(err$body[[1]],
+               "'testing' must be a number or a string representing a duration")
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -266,12 +266,6 @@ test_that("Duration to minutes works", {
   expect_equal(duration_to_minutes("40d"), 57600)
   expect_equal(duration_to_minutes("11d33h22m"), 17842)
   expect_equal(duration_to_minutes("11D33H22M"), 17842)  
-  expect_equal(duration_to_minutes("0"), 0)
-  expect_equal(duration_to_minutes("0d"), 0)
-  expect_equal(duration_to_minutes("0h"), 0)
-  expect_equal(duration_to_minutes("0m"), 0)
-  expect_equal(duration_to_minutes("0d0m"), 0)
-  expect_equal(duration_to_minutes("0d0h0m"), 0)
 })
 
 
@@ -292,6 +286,11 @@ test_that("report failure in duration to minutes nicely", {
                       "Invalid value for 'testing': TRUE")
   expect_equal(err$body[[1]],
                "'testing' must be a number or a string representing a duration")
+
+  err <- expect_error(duration_to_minutes("0"),
+                      "Invalid value for 'testing': 0")
+  expect_equal(err$body[[1]],
+               "'testing' is zero minutes")
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -265,6 +265,7 @@ test_that("Duration to minutes works", {
   expect_equal(duration_to_minutes("13h"), 780)
   expect_equal(duration_to_minutes("40d"), 57600)
   expect_equal(duration_to_minutes("11d33h22m"), 17842)
+  expect_equal(duration_to_minutes("11D33H22M"), 17842)  
   expect_equal(duration_to_minutes("0"), 0)
   expect_equal(duration_to_minutes("0d"), 0)
   expect_equal(duration_to_minutes("0h"), 0)

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -265,7 +265,7 @@ test_that("Duration to minutes works", {
   expect_equal(duration_to_minutes("13h"), 780)
   expect_equal(duration_to_minutes("40d"), 57600)
   expect_equal(duration_to_minutes("11d33h22m"), 17842)
-  expect_equal(duration_to_minutes("11D33H22M"), 17842)  
+  expect_equal(duration_to_minutes("11D33H22M"), 17842)
 })
 
 


### PR DESCRIPTION
This PR harmonises and tests errors thrown during resource validation, passing the call through for nicer tracebacks and trying to reflect the argument name back.  The main aim was to update calls to `expect_error()` to add strings that match the error.

Churny but I did manage to simplify some of the time handling, which R makes particularly painful.  This avoids a few roundtrips through strings, and is I think a little easier to reason about though there is quite a bit of fighting terrible classes still.

While doing this I was wondering where the use of "original" is but did not really see anything obvious. Do you remember?