### PR TITLE
Support for sending the hello job to fast queue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.36
+Version: 0.2.37
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/configure.R
+++ b/R/configure.R
@@ -156,6 +156,9 @@ hipercow_unconfigure <- function(driver, root = NULL) {
 ##'   permissions that are open only to the user who submitted the
 ##'   task.
 ##'
+##' @param check_hello Run any preflight checks before launching a
+##'   hello world task.  Return a validated resources list.
+##'
 ##' @param cluster_info Return information about a particular cluster:
 ##'   its maximum core count, maximum memory, node list and queue
 ##'   names, used for validating [hipercow_resources] against that
@@ -164,7 +167,8 @@ hipercow_unconfigure <- function(driver, root = NULL) {
 ##' @export
 hipercow_driver <- function(configure, submit, status, info, log, result,
                             cancel, provision_run, provision_list,
-                            provision_compare, keypair, cluster_info) {
+                            provision_compare, keypair, check_hello,
+                            cluster_info) {
   structure(list(configure = configure,
                  submit = submit,
                  status = status,
@@ -176,6 +180,7 @@ hipercow_driver <- function(configure, submit, status, info, log, result,
                  provision_list = provision_list,
                  provision_compare = provision_compare,
                  keypair = keypair,
+                 check_hello = check_hello,
                  cluster_info = cluster_info),
             class = "hipercow_driver")
 }

--- a/R/constants.R
+++ b/R/constants.R
@@ -7,4 +7,5 @@ STATUS_CANCELLED <- "status-cancelled"
 RESULT <- "result"
 DATA <- "data"
 INFO <- "info"
+RESOURCES <- "resources"
 # nolint end

--- a/R/example.R
+++ b/R/example.R
@@ -85,6 +85,7 @@ example_driver <- function() {
     provision_list = example_provision_list,
     provision_compare = example_provision_compare,
     keypair = example_keypair,
+    check_hello = example_check_hello,
     cluster_info = example_cluster_info)
 }
 
@@ -189,6 +190,10 @@ example_keypair <- function(config, path_root) {
   }
   list(pub = openssl::write_ssh(as.list(key)$pubkey),
        key = path_key)
+}
+
+
+example_check_hello <- function(config, path_root) {
 }
 
 

--- a/R/submit.R
+++ b/R/submit.R
@@ -46,6 +46,7 @@ task_submit <- function(id, ..., resources = NULL,
   for (i in id) {
     dat$driver$submit(i, resources, dat$config, root$path$root)
     writeLines(dat$name, file.path(root$path$tasks, i, STATUS_SUBMITTED))
+    saveRDS(resources, file.path(root$path$tasks, i, RESOURCES))
     root$cache$driver[[i]] <- dat$name
     if (n > 1) {
       cli::cli_progress_update()

--- a/R/windows.R
+++ b/R/windows.R
@@ -32,6 +32,9 @@ windows_authenticate <- function() {
 ##'
 ##' @title Check we can use windows cluster
 ##'
+##' @param path Path to check; typically this will be your working
+##'   directory.
+##'
 ##' @return Invisibly, a logical; `TRUE` if all checks succeed and
 ##'   `FALSE` otherwise.
 ##'
@@ -39,9 +42,9 @@ windows_authenticate <- function() {
 ##' @examplesIf FALSE
 ##'
 ##' windows_check()
-windows_check <- function() {
+windows_check <- function(path = getwd()) {
   ns <- ensure_package("hipercow.windows", rlang::current_env())
-  ns$windows_check()
+  ns$windows_check(path)
 }
 
 

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.36
+Version: 0.2.37
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/check.R
+++ b/drivers/windows/R/check.R
@@ -1,7 +1,7 @@
 windows_check <- function(path = getwd()) {
   ok <- windows_check_credentials()
   ok <- windows_check_connection() && ok
-  ## ok <- windows_check_path() && ok
+  ok <- windows_check_path(path) && ok
   invisible(ok)
 }
 
@@ -59,6 +59,22 @@ windows_check_connection <- function(timeout = 1) {
     FALSE
   } else {
     cli::cli_alert_success("Connection to private network working")
+    TRUE
+  }
+}
+
+
+windows_check_path <- function(path, mounts = detect_mounts()) {
+  path <- normalize_path(path)
+  result <- tryCatch(dide_add_extra_root_share(NULL, path, mounts),
+                     error = identity)
+  if (inherits(result, "error")) {
+    cli::cli_alert_danger("Failed to map path to a network share")
+    cli::cli_bullets(result$body)
+    FALSE
+  } else {
+    cli::cli_alert_success("Path looks like it is on a network share")
+    cli::cli_alert_info("Using '{path}'")
     TRUE
   }
 }

--- a/drivers/windows/R/check.R
+++ b/drivers/windows/R/check.R
@@ -1,6 +1,7 @@
-windows_check <- function() {
+windows_check <- function(path = getwd()) {
   ok <- windows_check_credentials()
   ok <- windows_check_connection() && ok
+  ## ok <- windows_check_path() && ok
   invisible(ok)
 }
 

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -11,6 +11,7 @@ hipercow_driver_windows <- function() {
     provision_list = windows_provision_list,
     provision_compare = windows_provision_compare,
     keypair = windows_keypair,
+    check_hello = windows_check_hello,
     cluster_info = windows_cluster_info)
 }
 
@@ -102,6 +103,18 @@ windows_cancel <- function(id, config, path_root) {
     time_started[cancelled] <- time_started(id[cancelled], path_root)
   }
   list(cancelled = cancelled, time_started = time_started)
+}
+
+
+windows_check_hello <- function(config, path_root) {
+  if (!windows_check()) {
+    cli::cli_abort("Not able to launch a task, given the above")
+  }
+  ## TODO: validate that path_root is on a network share; we should do
+  ## this within windows_check really
+  resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
+  resources$queue$computed <- "BuildQueue"
+  resources
 }
 
 

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -107,7 +107,7 @@ windows_cancel <- function(id, config, path_root) {
 
 
 windows_check_hello <- function(config, path_root) {
-  if (!windows_check()) {
+  if (!windows_check(path_root)) {
     cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -108,10 +108,8 @@ windows_cancel <- function(id, config, path_root) {
 
 windows_check_hello <- function(config, path_root) {
   if (!windows_check()) {
-    cli::cli_abort("Not able to launch a task, given the above")
+    cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
-  ## TODO: validate that path_root is on a network share; we should do
-  ## this within windows_check really
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
   resources$queue$computed <- "BuildQueue"
   resources

--- a/drivers/windows/R/mounts.R
+++ b/drivers/windows/R/mounts.R
@@ -191,7 +191,7 @@ dide_add_extra_root_share <- function(shares, path_root,
 ## pick from a late letter.
 available_drive <- function(shares, local_mount, prefer = NULL) {
   if (grepl("^[A-Za-z]:", local_mount)) {
-    local_mount
+    substr(local_mount, 1, 2)
   } else {
     used <- toupper(substr(vcapply(shares, "[[", "drive_remote"), 1, 1))
     pos <- c(prefer, LETTERS[22:26])

--- a/drivers/windows/tests/testthat/test-driver.R
+++ b/drivers/windows/tests/testthat/test-driver.R
@@ -277,3 +277,31 @@ test_that("can get task info", {
   mockery::expect_called(mock_client$status_job, 1)
   expect_equal(mockery::mock_args(mock_client$status_job)[[1]], list("1234"))
 })
+
+
+test_that("can check hello and switch to fast queue", {
+  mount <- withr::local_tempfile()
+  root <- example_root(mount, "b/c")
+  path_root <- root$path$root
+  config <- root$config$windows
+
+  mock_check <- mockery::mock(TRUE)
+  mockery::stub(windows_check_hello, "windows_check", mock_check)
+  res <- windows_check_hello(config, path_root)
+  expect_s3_class(res, "hipercow_resources")
+  expect_equal(res$queue$computed, "BuildQueue")
+})
+
+
+test_that("can check hello and fail fast if it won't work", {
+  mount <- withr::local_tempfile()
+  root <- example_root(mount, "b/c")
+  path_root <- root$path$root
+  config <- root$config$windows
+
+  mock_check <- mockery::mock(FALSE)
+  mockery::stub(windows_check_hello, "windows_check", mock_check)
+  expect_error(
+    windows_check_hello(config, path_root),
+    "Failed checks for using windows cluster; please see above")
+})

--- a/man/hipercow_driver.Rd
+++ b/man/hipercow_driver.Rd
@@ -16,6 +16,7 @@ hipercow_driver(
   provision_list,
   provision_compare,
   keypair,
+  check_hello,
   cluster_info
 )
 }
@@ -74,6 +75,9 @@ expected that this will call \code{conan2::conan_compare}}
 that will be accessible when the cluster runs, but with
 permissions that are open only to the user who submitted the
 task.}
+
+\item{check_hello}{Run any preflight checks before launching a
+hello world task.  Return a validated resources list.}
 
 \item{cluster_info}{Return information about a particular cluster:
 its maximum core count, maximum memory, node list and queue

--- a/man/hipercow_hello.Rd
+++ b/man/hipercow_hello.Rd
@@ -4,7 +4,7 @@
 \alias{hipercow_hello}
 \title{Hello world}
 \usage{
-hipercow_hello(progress = NULL, timeout = NULL)
+hipercow_hello(progress = NULL, timeout = NULL, driver = NULL)
 }
 \arguments{
 \item{progress}{Logical value, indicating if a progress spinner
@@ -14,9 +14,14 @@ interactive session.}
 
 \item{timeout}{The time to wait for the task to complete. The
 default is to wait forever.}
+
+\item{driver}{The driver to use to send the test task.  This can
+be omitted where you have exactly one driver, but we error if
+not given when you have more than one driver, or if you have not
+configured any drivers.}
 }
 \value{
-Unclear
+The string "Moo", direct from your cluster.
 }
 \description{
 Hello world in hipercow. This function sends a tiny test task

--- a/man/windows_check.Rd
+++ b/man/windows_check.Rd
@@ -4,7 +4,11 @@
 \alias{windows_check}
 \title{Check we can use windows cluster}
 \usage{
-windows_check()
+windows_check(path = getwd())
+}
+\arguments{
+\item{path}{Path to check; typically this will be your working
+directory.}
 }
 \value{
 Invisibly, a logical; \code{TRUE} if all checks succeed and

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -24,6 +24,7 @@ elsewhere_driver <- function() {
     provision_list = elsewhere_provision_list,
     provision_compare = elsewhere_provision_compare,
     keypair = elsewhere_keypair,
+    check_hello = elsewhere_check_hello,
     cluster_info = elsewhere_cluster_info)
 }
 
@@ -168,6 +169,10 @@ elsewhere_keypair <- function(config, path_root) {
   }
   list(pub = openssl::write_ssh(as.list(key)$pubkey),
        key = path_key)
+}
+
+
+elsewhere_check_hello <- function(config, path_root) {
 }
 
 

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -419,10 +419,11 @@ test_that("validate that status are reasonable", {
   init_quietly(path)
   b <- new_bundle("b", ids::random_id(3))
   expect_error(
-    hipercow_bundle_retry(b, if_status_in = "foo"),
+    hipercow_bundle_retry(b, if_status_in = "foo", root = path),
     "Invalid value for 'if_status_in': 'foo'")
   expect_error(
-    hipercow_bundle_retry(b, if_status_in = c("success", "foo", "created")),
+    hipercow_bundle_retry(b, if_status_in = c("success", "foo", "created"),
+                          root = path),
     "Invalid values for 'if_status_in': 'foo' and 'created'")
 })
 

--- a/tests/testthat/test-windows.R
+++ b/tests/testthat/test-windows.R
@@ -63,7 +63,7 @@ test_that("windows check passes through to hipercow.windows", {
 
   mockery::expect_called(mock_pkg$windows_check, 1)
   expect_equal(mockery::mock_args(mock_pkg$windows_check)[[1]],
-               list())
+               list(getwd()))
 })
 
 


### PR DESCRIPTION
This PR organises sending the hello world job through the fast queue.   No bootstrap update required, but we need to ensure that the windows driver and hipercow packages are both installed for it to work.

* new driver function that runs preflight checks and returns resources; this will be pretty general really
* the windows preflight checks now also check that the path is suitable
* resources are now saved as rds into the task directory, we can start using that when doing retries I think

There's one failure on windows only - Wes could you investigate? I think that it might just be that we need to do:

```
if (is_windows()) {
  paths<- windows_path(...)
}
```

in the tests or implementation but I am not really sure what is triggering this


