### PR TITLE
Drop "original" from all computed resources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.2.38
+Version: 0.2.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,8 @@
 S3method(c,hipercow_envvars)
 S3method(print,hipercow_bundle)
 S3method(print,hipercow_environment)
+S3method(print,hipercow_parallel)
+S3method(print,hipercow_resources)
 S3method(print,hipercow_task_info)
 export(hipercow)
 export(hipercow_bundle_cancel)

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -140,3 +140,9 @@ hipercow_parallel_setup_parallel <- function(cores) {
   # later on we'll also load some packages, source some files
   cli::cli_alert_success("Cluster ready to use")
 }
+
+
+##' @export
+print.hipercow_parallel <- function(x, ...) {
+  print_simple_s3(x, "hipercow parallel control (hipercow_parallel)")
+}

--- a/R/resource.R
+++ b/R/resource.R
@@ -109,32 +109,29 @@ hipercow_resources <- function(cores = 1L,
 
 validate_cores <- function(cores, call = NULL) {
   assert_scalar(cores, call = call)
-  if (!identical(cores, Inf)) {
-    if (is.na(cores) || !rlang::is_integerish(cores) || cores <= 0) {
-      cli::cli_abort(
-        c("Invalid value for 'cores': {cores}",
-          i = "Number of cores must be a positive integer, or 'Inf'"),
-        call = call, arg = "cores")
-    }
-    computed <- as.integer(cores)
-  } else {
-    computed <- Inf
+  if (identical(cores, Inf)) {
+    return(Inf)
   }
-  list(computed = computed)
+  if (is.na(cores) || !rlang::is_integerish(cores) || cores <= 0) {
+    cli::cli_abort(
+      c("Invalid value for 'cores': {cores}",
+        i = "Number of cores must be a positive integer, or 'Inf'"),
+      call = call, arg = "cores")
+  }
+  as.integer(cores)
 }
 
 validate_exclusive <- function(exclusive) {
   assert_scalar_logical(exclusive)
-  list(computed = exclusive)
+  exclusive
 }
 
 validate_max_runtime <- function(max_runtime, call = NULL) {
   if (is.null(max_runtime)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
   assert_scalar(max_runtime, call = call)
-  computed <- duration_to_minutes(max_runtime, "max_runtime", call)
-  list(computed = computed)
+  duration_to_minutes(max_runtime, "max_runtime", call)
 
 }
 
@@ -145,7 +142,7 @@ hold_until_special <- c("tonight", "midnight", "weekend")
 
 validate_hold_until <- function(hold_until, call = NULL) {
   if (is.null(hold_until)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
 
   assert_scalar(hold_until)
@@ -161,13 +158,13 @@ validate_hold_until <- function(hold_until, call = NULL) {
   } else {
     computed <- duration_to_minutes(hold_until, "hold_until")
   }
-  list(computed = computed)
+  computed
 }
 
 
 validate_memory <- function(value, name, call = NULL) {
   if (is.null(value)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
 
   assert_scalar(value, name = name, call = call)
@@ -207,21 +204,20 @@ validate_memory <- function(value, name, call = NULL) {
       call = call, arg = name)
   }
 
-  list(computed = computed)
+  computed
 }
 
 validate_nodes <- function(nodes, call = NULL) {
   if (is.null(nodes)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
-
   assert_character(nodes, call = call)
-  list(computed = unique(trimws(nodes)))
+  unique(trimws(nodes))
 }
 
 validate_priority <- function(priority, call = call) {
   if (is.null(priority)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
 
   assert_scalar_character(priority)
@@ -233,16 +229,15 @@ validate_priority <- function(priority, call = call) {
       "Could not understand priority '{priority}'",
       i = "Priority can only be 'low' or 'normal'"))
   }
-  list(computed = priority)
+  priority
 }
 
 validate_queue <- function(queue, call = call) {
   if (is.null(queue)) {
-    return(list(computed = NULL))
+    return(NULL)
   }
-
   assert_scalar_character(queue, call = call)
-  list(computed = trimws(queue))
+  trimws(queue)
 }
 
 
@@ -300,25 +295,22 @@ resources_validate <- function(resources, driver, root) {
   }
   cluster_resources <- cluster_info(driver, root)$resources
 
-  if (is.null(resources$queue$computed)) {
-    resources$queue$computed <- cluster_resources$default_queue
+  if (is.null(resources$queue)) {
+    resources$queue <- cluster_resources$default_queue
   }
 
-  validate_cluster_cores(resources$cores$computed, cluster_resources$max_cores)
+  validate_cluster_cores(resources$cores, cluster_resources$max_cores)
 
   validate_cluster_memory(
-    resources$cores$memory_per_node$computed, cluster_resources$max_ram,
-    "node")
-
+    resources$memory_per_node, cluster_resources$max_ram, "node")
   validate_cluster_memory(
-    resources$cores$memory_per_process$computed, cluster_resources$max_ram,
-    "process")
+    resources$memory_per_process, cluster_resources$max_ram, "process")
 
   validate_cluster_queue(
-    resources$queue$computed, cluster_resources$queues)
+    resources$queue, cluster_resources$queues)
 
   validate_cluster_requested_nodes(
-    resources$requested_nodes$computed, cluster_resources$nodes)
+    resources$requested_nodes, cluster_resources$nodes)
 
   attr(resources, "validated") <- driver
   resources

--- a/R/resource.R
+++ b/R/resource.R
@@ -357,3 +357,9 @@ validate_cluster_requested_nodes <- function(nodes, cluster_nodes) {
     }
   }
 }
+
+
+##' @export
+print.hipercow_resources <- function(x, ...) {
+  print_simple_s3(x, "hipercow resource control (hipercow_resources)")
+}

--- a/R/resource.R
+++ b/R/resource.R
@@ -120,21 +120,21 @@ validate_cores <- function(cores, call = NULL) {
   } else {
     computed <- Inf
   }
-  list(original = cores, computed = computed)
+  list(computed = computed)
 }
 
 validate_exclusive <- function(exclusive) {
   assert_scalar_logical(exclusive)
-  list(original = exclusive, computed = exclusive)
+  list(computed = exclusive)
 }
 
 validate_max_runtime <- function(max_runtime, call = NULL) {
   if (is.null(max_runtime)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
   assert_scalar(max_runtime, call = call)
   computed <- duration_to_minutes(max_runtime, "max_runtime", call)
-  list(original = max_runtime, computed = computed)
+  list(computed = computed)
 
 }
 
@@ -145,7 +145,7 @@ hold_until_special <- c("tonight", "midnight", "weekend")
 
 validate_hold_until <- function(hold_until, call = NULL) {
   if (is.null(hold_until)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
 
   assert_scalar(hold_until)
@@ -161,13 +161,13 @@ validate_hold_until <- function(hold_until, call = NULL) {
   } else {
     computed <- duration_to_minutes(hold_until, "hold_until")
   }
-  list(original = hold_until, computed = computed)
+  list(computed = computed)
 }
 
 
 validate_memory <- function(value, name, call = NULL) {
   if (is.null(value)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
 
   assert_scalar(value, name = name, call = call)
@@ -207,21 +207,21 @@ validate_memory <- function(value, name, call = NULL) {
       call = call, arg = name)
   }
 
-  list(original = value, computed = computed)
+  list(computed = computed)
 }
 
 validate_nodes <- function(nodes, call = NULL) {
   if (is.null(nodes)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
 
   assert_character(nodes, call = call)
-  list(original = nodes, computed = unique(trimws(nodes)))
+  list(computed = unique(trimws(nodes)))
 }
 
 validate_priority <- function(priority, call = call) {
   if (is.null(priority)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
 
   assert_scalar_character(priority)
@@ -233,16 +233,16 @@ validate_priority <- function(priority, call = call) {
       "Could not understand priority '{priority}'",
       i = "Priority can only be 'low' or 'normal'"))
   }
-  list(original = priority, computed = priority)
+  list(computed = priority)
 }
 
 validate_queue <- function(queue, call = call) {
   if (is.null(queue)) {
-    return(list(original = NULL, computed = NULL))
+    return(list(computed = NULL))
   }
 
   assert_scalar_character(queue, call = call)
-  list(original = queue, computed = trimws(queue))
+  list(computed = trimws(queue))
 }
 
 

--- a/R/resource.R
+++ b/R/resource.R
@@ -1,4 +1,7 @@
-##' Specify what resources a task requires to run.
+##' Specify what resources a task requires to run.  This creates a
+##' validated list of resources that can be passed in as the
+##' `resources` argument to [task_create_expr] or other task
+##' creation functions.
 ##'
 ##' # Windows cluster (`wpia-hn`)
 ##'
@@ -69,17 +72,23 @@
 ##'   of parameters which is syntactically valid, although not yet
 ##'   validated against a particular driver to see if the resources can be
 ##'   satisfied. If the function fails, it will return information
-##'   about why the arguments could not be validated.
+##'   about why the arguments could not be validated. Do not modify the
+##'   return value.
 ##'
 ##' @export
 ##' @examples
+##' # The default set of resources
 ##' hipercow_resources()
 ##'
 ##' # A more complex case:
-##' r <- hipercow_resources(
+##' hipercow_resources(
 ##'   cores = 32,
 ##'   exclusive = TRUE,
 ##'   priority = "low")
+##'
+##' # (remember that in order to change resources you would pass the
+##' # return value here into the "resources" argument of
+##' # task_create_expr() or similar)
 hipercow_resources <- function(cores = 1L,
                                exclusive = FALSE,
                                max_runtime = NULL,

--- a/R/submit.R
+++ b/R/submit.R
@@ -28,10 +28,10 @@ task_submit <- function(id, ..., resources = NULL,
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   resources <- resources_validate(resources, driver, root)
   dat <- hipercow_driver_prepare(driver, root, environment())
-  set_special_time <- !is.null(resources$hold_until$computed) &&
-    resources$hold_until$computed %in% hold_until_special
+  set_special_time <- !is.null(resources$hold_until) &&
+    resources$hold_until %in% hold_until_special
   if (set_special_time) {
-    resources$hold_until$computed <- special_time(resources$hold_until$computed)
+    resources$hold_until <- special_time(resources$hold_until)
   }
 
   n <- length(id)

--- a/R/util.R
+++ b/R/util.R
@@ -409,3 +409,16 @@ as_time <- function(...) {
   }
   ret
 }
+
+
+print_simple_s3 <- function(x, name = class(x)[[1]]) {
+  cli::cli_h1(name)
+  i <- vlapply(x, is.null)
+  for (nm in names(x)[!i]) {
+    cli::cli_li("{nm}: {x[[nm]] %||% ''}")
+  }
+  if (any(i)) {
+    cli::cli_text("Unset: {squote(names(x)[i])}")
+  }
+  invisible(x)
+}

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.2.38
+Version: 0.2.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -111,7 +111,7 @@ windows_check_hello <- function(config, path_root) {
     cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
-  resources$queue$computed <- "BuildQueue"
+  resources$queue <- "BuildQueue"
   resources
 }
 

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -26,7 +26,7 @@ windows_provision_run <- function(args, config, path_root) {
 
   res <- hipercow::hipercow_resources()
   res <- hipercow::hipercow_resources_validate(res, root = path_root)
-  res$queue <- list(computed = "BuildQueue")
+  res$queue <- "BuildQueue"
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
 
   path_dide_id <- file.path(dirname(path_batch), DIDE_ID)

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -26,7 +26,7 @@ windows_provision_run <- function(args, config, path_root) {
 
   res <- hipercow::hipercow_resources()
   res <- hipercow::hipercow_resources_validate(res, root = path_root)
-  res$queue <- list(original = "", computed = "BuildQueue")
+  res$queue <- list(computed = "BuildQueue")
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
 
   path_dide_id <- file.path(dirname(path_batch), DIDE_ID)

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -228,7 +228,7 @@ client_body_submit <- function(path, name, resources, cluster,
   stderr <- ""
   stdout <- ""
   req <- list(cluster = encode64(cluster),
-              template = encode64(resources$queue$computed),
+              template = encode64(resources$queue),
               jn = encode64(name),
               wd = encode64(workdir),
               se = encode64(stderr),
@@ -237,34 +237,34 @@ client_body_submit <- function(path, name, resources, cluster,
               dep = encode64(deps),
               hpcfunc = "submit")
 
-  if (resources$cores$computed == Inf) {
+  if (resources$cores == Inf) {
     req$rc <- encode64("1")
     req$rt <- encode64("Nodes")
   } else {
-    req$rc <- encode64(as.character(resources$cores$computed))
+    req$rc <- encode64(as.character(resources$cores))
     req$rt <- encode64("Cores")
   }
 
-  if (resources$exclusive$computed) {
+  if (resources$exclusive) {
     req$exc <- encode64("1")
   }
 
-  if (!is.null(resources$memory_per_node$computed)) {
+  if (!is.null(resources$memory_per_node)) {
     req$mpn <- encode64(as.character(
-      1000 * resources$memory_per_node$computed))
+      1000 * resources$memory_per_node))
   }
 
-  if (!is.null(resources$memory_per_process$computed)) {
+  if (!is.null(resources$memory_per_process)) {
     req$epm <- encode64(as.character(
-      1000 * resources$memory_per_process$computed))
+      1000 * resources$memory_per_process))
   }
 
-  if (!is.null(resources$max_runtime$computed)) {
-    req$rnt <- encode64(as.character(resources$max_runtime$computed))
+  if (!is.null(resources$max_runtime)) {
+    req$rnt <- encode64(as.character(resources$max_runtime))
   }
 
-  if (!is.null(resources$hold_until$computed)) {
-    datetime <- resources$hold_until$computed
+  if (!is.null(resources$hold_until)) {
+    datetime <- resources$hold_until
     if (is.numeric(datetime)) {
       req$hu <- encode64(as.character(datetime))
     } else {
@@ -272,13 +272,13 @@ client_body_submit <- function(path, name, resources, cluster,
     }
   }
 
-  if (!is.null(resources$requested_nodes$computed)) {
+  if (!is.null(resources$requested_nodes)) {
     req$rn <- encode64(
-      paste(resources$requested_nodes$computed, collapse = ","))
+      paste(resources$requested_nodes, collapse = ","))
   }
 
-  if (!is.null(resources$priority$computed)) {
-    req$pri <- encode64(resources$priority$computed)
+  if (!is.null(resources$priority)) {
+    req$pri <- encode64(resources$priority)
   }
 
   req

--- a/drivers/windows/tests/testthat/test-driver.R
+++ b/drivers/windows/tests/testthat/test-driver.R
@@ -289,7 +289,7 @@ test_that("can check hello and switch to fast queue", {
   mockery::stub(windows_check_hello, "windows_check", mock_check)
   res <- windows_check_hello(config, path_root)
   expect_s3_class(res, "hipercow_resources")
-  expect_equal(res$queue$computed, "BuildQueue")
+  expect_equal(res$queue, "BuildQueue")
 })
 
 

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -32,7 +32,7 @@ test_that("can run provision script", {
   expect_length(args, 3)
   expect_identical(args[[1]], batch_path)
   expect_identical(args[[2]], id)
-  expect_identical(args[[3]]$queue$computed, "BuildQueue")
+  expect_identical(args[[3]]$queue, "BuildQueue")
 
   mockery::expect_called(mock_client$status_job, 4)
   expect_equal(mockery::mock_args(mock_client$status_job),

--- a/drivers/windows/tests/testthat/test-web-support.R
+++ b/drivers/windows/tests/testthat/test-web-support.R
@@ -16,9 +16,9 @@ test_that("Check cluster usage", {
 test_that("Construct a submit body", {
   p <- "\\\\fi--host\\\\path"
   resources <- list(
-    cores = list(computed = 1),
-    exclusive = list(computed = FALSE),
-    queue = list(computed = "GeneralNodes"))
+    cores = 1,
+    exclusive = FALSE,
+    queue = "GeneralNodes")
 
   d <- client_body_submit(p, "name", resources, "fi--dideclusthn",
                           c("1", "2"))

--- a/drivers/windows/tests/testthat/test-web.R
+++ b/drivers/windows/tests/testthat/test-web.R
@@ -240,9 +240,9 @@ test_that("submit sends correct payload", {
   cl <- web_client$new(login = FALSE, client = mock_client)
   path <- "\\\\host\\path"
   resources <- list(
-    cores = list(computed = 1),
-    exclusive = list(computed = FALSE),
-    queue = list(computed = "GeneralNodes"))
+    cores = 1,
+    exclusive = FALSE,
+    queue = "GeneralNodes")
 
   expect_equal(
     cl$submit(path, "name", resources = resources,
@@ -303,8 +303,8 @@ test_that("hipercow_resources processed into web api call", {
   expect_equal(cbs$pri, encode64("low"))
 
   now <- Sys.time() + 1
-  res$hold_until$computed <- now
-  res$cores$computed <- 3
+  res$hold_until <- now
+  res$cores <- 3
   cbs <- client_body_submit(path = path, name = "Cow", res, "hermod",
                             depends_on = c(123, 456))
 

--- a/man/hipercow_resources.Rd
+++ b/man/hipercow_resources.Rd
@@ -73,10 +73,14 @@ If the function succeeds, it returns a \code{hipercow_resources} list
 of parameters which is syntactically valid, although not yet
 validated against a particular driver to see if the resources can be
 satisfied. If the function fails, it will return information
-about why the arguments could not be validated.
+about why the arguments could not be validated. Do not modify the
+return value.
 }
 \description{
-Specify what resources a task requires to run.
+Specify what resources a task requires to run.  This creates a
+validated list of resources that can be passed in as the
+\code{resources} argument to \link{task_create_expr} or other task
+creation functions.
 }
 \section{Windows cluster (\code{wpia-hn})}{
 \itemize{
@@ -93,11 +97,16 @@ Coming Soon.
 }
 
 \examples{
+# The default set of resources
 hipercow_resources()
 
 # A more complex case:
-r <- hipercow_resources(
+hipercow_resources(
   cores = 32,
   exclusive = TRUE,
   priority = "low")
+
+# (remember that in order to change resources you would pass the
+# return value here into the "resources" argument of
+# task_create_expr() or similar)
 }

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -123,3 +123,23 @@ test_that("Can set cores and environment variables", {
     expect_equal(Sys.getenv("MC_CORES"), "4")
   })
 })
+
+
+test_that("can print default parallel control", {
+  x <- hipercow_parallel()
+  res <- evaluate_promise(print(x))
+  expect_match(res$messages, "hipercow parallel control (hipercow_parallel)",
+               all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "Unset: 'method'",
+               all = FALSE, fixed = TRUE)
+})
+
+
+test_that("can print parallel control", {
+  x <- hipercow_parallel("parallel")
+  res <- evaluate_promise(print(x))
+  expect_match(res$messages, "hipercow parallel control (hipercow_parallel)",
+               all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "method: parallel",
+               all = FALSE, fixed = TRUE)
+})

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -223,3 +223,15 @@ test_that("don't revalidate things that are flagged as valid", {
   expect_error(resources_validate(r, "example", root),
                "999 is too many cores for this cluster")
 })
+
+
+test_that("can print default resource control", {
+  x <- hipercow_resources()
+  res <- evaluate_promise(print(x))
+  expect_match(res$messages, "hipercow resource control (hipercow_resources)",
+               all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "cores: 1", all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "exclusive: FALSE", all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "Unset: 'max_runtime',",
+               all = FALSE, fixed = TRUE)
+})

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -1,6 +1,6 @@
 test_that("Validate resource args", {
-  expect_equal(validate_cores(Inf), list(computed = Inf))
-  expect_equal(validate_cores(1), list(computed = 1L))
+  expect_equal(validate_cores(Inf), Inf)
+  expect_equal(validate_cores(1), 1L)
 
   expect_error(validate_cores(-Inf),
                "Invalid value for 'cores': -Inf")
@@ -20,12 +20,9 @@ test_that("Validate resource args", {
 
 
 test_that("validate max_runtime", {
-  expect_equal(validate_max_runtime(NULL),
-               list(computed = NULL))
-  expect_equal(validate_max_runtime(35),
-               list(computed = 35))
-  expect_equal(validate_max_runtime("2h35m"),
-               list(computed = 155))
+  expect_null(validate_max_runtime(NULL))
+  expect_equal(validate_max_runtime(35), 35)
+  expect_equal(validate_max_runtime("2h35m"), 155)
 
   expect_error(
     validate_max_runtime("0"),
@@ -43,32 +40,24 @@ test_that("validate max_runtime", {
 
 
 test_that("validate hold_until", {
-  expect_equal(validate_hold_until(NULL),
-               list(computed = NULL))
-  expect_equal(validate_hold_until("tonight"),
-               list(computed = "tonight"))
-  expect_equal(validate_hold_until("midnight"),
-               list(computed = "midnight"))
+  expect_null(validate_hold_until(NULL))
+  expect_equal(validate_hold_until("tonight"), "tonight")
+  expect_equal(validate_hold_until("midnight"), "midnight")
 
   expect_error(
     validate_hold_until(0),
     "Invalid value for 'hold_until': 0")
-  expect_equal(validate_hold_until(60),
-               list(computed = 60))
-  expect_equal(validate_hold_until("2h30m"),
-               list(computed = 150))
-  expect_equal(validate_hold_until("1d1h1m"),
-               list(computed = 1501))
+  expect_equal(validate_hold_until(60), 60)
+  expect_equal(validate_hold_until("2h30m"), 150)
+  expect_equal(validate_hold_until("1d1h1m"), 1501)
   tomorrow <- Sys.Date() + 1
-  expect_equal(validate_hold_until(tomorrow),
-               list(computed = as.POSIXlt(tomorrow)))
+  expect_equal(validate_hold_until(tomorrow), as.POSIXlt(tomorrow))
   today <- Sys.Date()
   expect_error(validate_hold_until(today),
                "Invalid value for 'hold_until'")
 
   soon <- Sys.time() + 120
-  expect_equal(validate_hold_until(soon),
-               list(computed = as.POSIXlt(soon)))
+  expect_equal(validate_hold_until(soon), as.POSIXlt(soon))
   err <- expect_error(validate_hold_until(Sys.time() - 1),
                       "Invalid value for 'hold_until'")
   expect_match(err$body[[1]], "is in the past")
@@ -76,22 +65,17 @@ test_that("validate hold_until", {
 
 
 test_that("validate memory", {
-  expect_equal(validate_memory(NULL, "mem"),
-               list(computed = NULL))
+  expect_null(validate_memory(NULL, "mem"))
   expect_error(
     validate_memory(c("a", "b"), "mem"),
     "'mem' must be a scalar")
   expect_error(
     validate_memory("10M", "mem"),
     "Invalid string representation of memory for 'mem': 10M")
-  expect_equal(validate_memory(1, "mem"),
-               list(computed = 1))
-  expect_equal(validate_memory("1", "mem"),
-               list(computed = 1))
-  expect_equal(validate_memory("9G", "mem"),
-               list(computed = 9))
-  expect_equal(validate_memory("2T", "mem"),
-               list(computed = 2000))
+  expect_equal(validate_memory(1, "mem"), 1)
+  expect_equal(validate_memory("1", "mem"), 1)
+  expect_equal(validate_memory("9G", "mem"), 9)
+  expect_equal(validate_memory("2T", "mem"), 2000)
   expect_error(validate_memory("1G2T", "mem"),
                "Invalid string representation of memory for 'mem': 1G2T")
   expect_error(validate_memory("1GG", "mem"),
@@ -118,24 +102,19 @@ test_that("validate memory", {
 
 
 test_that("validate nodes", {
-  expect_equal(validate_nodes(NULL), list(computed = NULL))
-  expect_equal(validate_nodes(c("A", "B")),
-               list(computed = c("A", "B")))
-  expect_equal(validate_nodes(c("A", "A")),
-               list(computed = "A"))
-  expect_equal(validate_nodes("A"),
-               list(computed = "A"))
+  expect_null(validate_nodes(NULL))
+  expect_equal(validate_nodes(c("A", "B")), c("A", "B"))
+  expect_equal(validate_nodes(c("A", "A")), "A")
+  expect_equal(validate_nodes("A"), "A")
   expect_error(validate_nodes(NA),
                "'nodes' must be a character")
 })
 
 
 test_that("validate priority", {
-  expect_equal(validate_priority(NULL), list(computed = NULL))
-  expect_equal(validate_priority("low"),
-               list(computed = "low"))
-  expect_equal(validate_priority("normal"),
-               list(computed = "normal"))
+  expect_null(validate_priority(NULL))
+  expect_equal(validate_priority("low"), "low")
+  expect_equal(validate_priority("normal"), "normal")
   expect_error(validate_priority(3000),
                "'priority' must be a character")
 })
@@ -155,8 +134,8 @@ test_that("prevent high priorities", {
 
 
 test_that("validate queue", {
-  expect_equal(validate_queue(NULL), list(computed = NULL))
-  expect_equal(validate_queue("Q"), list(computed = "Q"))
+  expect_null(validate_queue(NULL), NULL)
+  expect_equal(validate_queue("Q"), "Q")
   expect_error(validate_queue(NA),
                "'queue' must be a character")
   expect_error(validate_queue(c("a", "b")),
@@ -167,8 +146,8 @@ test_that("validate queue", {
 test_that("Can get a hipercow_resources", {
   res <- hipercow_resources()
   expect_s3_class(res, "hipercow_resources")
-  expect_equal(res$cores$computed, 1)
-  expect_equal(res$exclusive$computed, FALSE)
+  expect_equal(res$cores, 1)
+  expect_equal(res$exclusive, FALSE)
 })
 
 
@@ -189,14 +168,15 @@ test_that("Can validate resources against driver", {
   expect_true("kevin" %in% cluster_info$resources$nodes)
   expect_true("Tesco" %in% cluster_info$resources$queues)
 
-  res <- hipercow_resources(cores = 1, memory_per_node = 5,
+  res <- hipercow_resources(cores = 1,
+                            memory_per_node = 5,
                             memory_per_process = 5,
                             requested_nodes = "Kevin")
 
   res2 <- hipercow_resources_validate(res, driver = "elsewhere",
-                                          root = root)
+                                      root = root)
 
-  expect_equal(res2$queue$computed, "Aldi")
+  expect_equal(res2$queue, "Aldi")
 })
 
 
@@ -237,7 +217,7 @@ test_that("don't revalidate things that are flagged as valid", {
   root <- hipercow_root(path)
 
   r <- hipercow_resources()
-  r$cores$computed <- 999
+  r$cores <- 999
   attr(r, "validated") <- "foo"
   expect_identical(resources_validate(r, "foo", root), r)
   expect_error(resources_validate(r, "example", root),

--- a/tests/testthat/test-resource.R
+++ b/tests/testthat/test-resource.R
@@ -1,6 +1,6 @@
 test_that("Validate resource args", {
-  expect_equal(validate_cores(Inf), list(original = Inf, computed = Inf))
-  expect_equal(validate_cores(1), list(original = 1, computed = 1L))
+  expect_equal(validate_cores(Inf), list(computed = Inf))
+  expect_equal(validate_cores(1), list(computed = 1L))
 
   expect_error(validate_cores(-Inf),
                "Invalid value for 'cores': -Inf")
@@ -21,11 +21,11 @@ test_that("Validate resource args", {
 
 test_that("validate max_runtime", {
   expect_equal(validate_max_runtime(NULL),
-               list(original = NULL, computed = NULL))
+               list(computed = NULL))
   expect_equal(validate_max_runtime(35),
-               list(original = 35, computed = 35))
+               list(computed = 35))
   expect_equal(validate_max_runtime("2h35m"),
-               list(original = "2h35m", computed = 155))
+               list(computed = 155))
 
   expect_error(
     validate_max_runtime("0"),
@@ -44,31 +44,31 @@ test_that("validate max_runtime", {
 
 test_that("validate hold_until", {
   expect_equal(validate_hold_until(NULL),
-               list(original = NULL, computed = NULL))
+               list(computed = NULL))
   expect_equal(validate_hold_until("tonight"),
-               list(original = "tonight", computed = "tonight"))
+               list(computed = "tonight"))
   expect_equal(validate_hold_until("midnight"),
-               list(original = "midnight", computed = "midnight"))
+               list(computed = "midnight"))
 
   expect_error(
     validate_hold_until(0),
     "Invalid value for 'hold_until': 0")
   expect_equal(validate_hold_until(60),
-               list(original = 60, computed = 60))
+               list(computed = 60))
   expect_equal(validate_hold_until("2h30m"),
-               list(original = "2h30m", computed = 150))
+               list(computed = 150))
   expect_equal(validate_hold_until("1d1h1m"),
-               list(original = "1d1h1m", computed = 1501))
+               list(computed = 1501))
   tomorrow <- Sys.Date() + 1
   expect_equal(validate_hold_until(tomorrow),
-               list(original = tomorrow, computed = as.POSIXlt(tomorrow)))
+               list(computed = as.POSIXlt(tomorrow)))
   today <- Sys.Date()
   expect_error(validate_hold_until(today),
                "Invalid value for 'hold_until'")
 
   soon <- Sys.time() + 120
   expect_equal(validate_hold_until(soon),
-               list(original = soon, computed = as.POSIXlt(soon)))
+               list(computed = as.POSIXlt(soon)))
   err <- expect_error(validate_hold_until(Sys.time() - 1),
                       "Invalid value for 'hold_until'")
   expect_match(err$body[[1]], "is in the past")
@@ -77,7 +77,7 @@ test_that("validate hold_until", {
 
 test_that("validate memory", {
   expect_equal(validate_memory(NULL, "mem"),
-               list(original = NULL, computed = NULL))
+               list(computed = NULL))
   expect_error(
     validate_memory(c("a", "b"), "mem"),
     "'mem' must be a scalar")
@@ -85,13 +85,13 @@ test_that("validate memory", {
     validate_memory("10M", "mem"),
     "Invalid string representation of memory for 'mem': 10M")
   expect_equal(validate_memory(1, "mem"),
-               list(original = 1, computed = 1))
+               list(computed = 1))
   expect_equal(validate_memory("1", "mem"),
-               list(original = "1", computed = 1))
+               list(computed = 1))
   expect_equal(validate_memory("9G", "mem"),
-               list(original = "9G", computed = 9))
+               list(computed = 9))
   expect_equal(validate_memory("2T", "mem"),
-               list(original = "2T", computed = 2000))
+               list(computed = 2000))
   expect_error(validate_memory("1G2T", "mem"),
                "Invalid string representation of memory for 'mem': 1G2T")
   expect_error(validate_memory("1GG", "mem"),
@@ -118,24 +118,24 @@ test_that("validate memory", {
 
 
 test_that("validate nodes", {
-  expect_equal(validate_nodes(NULL), list(original = NULL, computed = NULL))
+  expect_equal(validate_nodes(NULL), list(computed = NULL))
   expect_equal(validate_nodes(c("A", "B")),
-               list(original = c("A", "B"), computed = c("A", "B")))
+               list(computed = c("A", "B")))
   expect_equal(validate_nodes(c("A", "A")),
-               list(original = c("A", "A"), computed = "A"))
+               list(computed = "A"))
   expect_equal(validate_nodes("A"),
-               list(original = "A", computed = "A"))
+               list(computed = "A"))
   expect_error(validate_nodes(NA),
                "'nodes' must be a character")
 })
 
 
 test_that("validate priority", {
-  expect_equal(validate_priority(NULL), list(original = NULL, computed = NULL))
+  expect_equal(validate_priority(NULL), list(computed = NULL))
   expect_equal(validate_priority("low"),
-               list(original = "low", computed = "low"))
+               list(computed = "low"))
   expect_equal(validate_priority("normal"),
-               list(original = "normal", computed = "normal"))
+               list(computed = "normal"))
   expect_error(validate_priority(3000),
                "'priority' must be a character")
 })
@@ -155,8 +155,8 @@ test_that("prevent high priorities", {
 
 
 test_that("validate queue", {
-  expect_equal(validate_queue(NULL), list(original = NULL, computed = NULL))
-  expect_equal(validate_queue("Q"), list(original = "Q", computed = "Q"))
+  expect_equal(validate_queue(NULL), list(computed = NULL))
+  expect_equal(validate_queue("Q"), list(computed = "Q"))
   expect_error(validate_queue(NA),
                "'queue' must be a character")
   expect_error(validate_queue(c("a", "b")),


### PR DESCRIPTION
Seems ok throughout with this change.

Also added a print method for `hipercow_resources` and `hipercow_parallel`; both very simple and using the same little utility function