### PR TITLE
Validate that bundle and environment names are safe

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/bundle.R
+++ b/R/bundle.R
@@ -13,7 +13,9 @@
 ##'   plausible.
 ##'
 ##' @param name A string, the name for the bundle.  If not given, then
-##'   a random name is generated.
+##'   a random name is generated.  Names can contain letters, numbers,
+##'   underscores and hyphens, but cannot contain other special
+##'   characters.
 ##'
 ##' @param overwrite Logical, indicating that we should overwrite any
 ##'   existing bundle with the same name.
@@ -50,7 +52,7 @@ hipercow_bundle_create <- function(ids, name = NULL, validate = TRUE,
   if (is.null(name)) {
     name <- ids::adjective_animal()
   } else {
-    assert_scalar_character(name)
+    check_safe_name_for_filename(name, "bundle", rlang::current_env())
   }
   assert_scalar_logical(validate)
   assert_scalar_logical(overwrite)

--- a/R/environment.R
+++ b/R/environment.R
@@ -4,7 +4,8 @@
 ##'
 ##' @param name Name of the environment. The name `default` is
 ##'   special; this is the environment that will be used by default
-##'   (hence the name!).
+##'   (hence the name!).  Environment names can contain letters,
+##'   numbers, hyphens and underscores.
 ##'
 ##' @param sources Files to source before starting a task. These will
 ##'   be sourced into the global (or execution) environment of the
@@ -56,6 +57,13 @@ hipercow_environment_create <- function(name = "default", packages = NULL,
                                         sources = NULL, globals = NULL,
                                         overwrite = TRUE, root = NULL) {
   root <- hipercow_root(root)
+
+  assert_scalar_character(name)
+  if (name == "empty") {
+    cli::cli_abort("Can't create environment with special name 'empty'",
+                   name = "name")
+  }
+  check_safe_name_for_filename(name, "environment", rlang::current_env())
 
   ret <- new_environment(name, packages, sources, globals,
                          root, rlang::current_env())
@@ -164,7 +172,7 @@ ensure_environment_exists <- function(name, root, call) {
   assert_scalar_character(name)
   path <- file.path(root$path$environments, name)
   if (!file.exists(path)) {
-    if (name != "default") {
+    if (!(name %in% c("default", "empty"))) {
       cli::cli_abort(
         c("Environment '{name}' does not exist",
           i = "Valid options are: {squote(hipercow_environment_list(root))}"),

--- a/R/util.R
+++ b/R/util.R
@@ -422,3 +422,17 @@ print_simple_s3 <- function(x, name = class(x)[[1]]) {
   }
   invisible(x)
 }
+
+
+check_safe_name_for_filename <- function(name, what, call = NULL) {
+  assert_scalar_character(name, name = "name", call = call)
+  if (!grepl("^[a-zA-Z0-9_-]+$", name)) {
+    what_upper <- paste0(toupper(substr(what, 1, 1)),
+                         substr(what, 2, nchar(what)))
+    cli::cli_abort(
+      c("Invalid {what} name '{name}'",
+        i = paste("{what_upper} names can contain letters, numbers, hyphens",
+                  "and underscores only")),
+      arg = "name", call = call)
+  }
+}

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/man/hipercow_bundle_create.Rd
+++ b/man/hipercow_bundle_create.Rd
@@ -16,7 +16,9 @@ hipercow_bundle_create(
 \item{ids}{A character vector of task ids}
 
 \item{name}{A string, the name for the bundle.  If not given, then
-a random name is generated.}
+a random name is generated.  Names can contain letters, numbers,
+underscores and hyphens, but cannot contain other special
+characters.}
 
 \item{validate}{Logical, indicating if we should check that the
 task ids exist.  We always check that the task ids are

--- a/man/hipercow_environment.Rd
+++ b/man/hipercow_environment.Rd
@@ -28,7 +28,8 @@ hipercow_environment_exists(name = "default", root = NULL)
 \arguments{
 \item{name}{Name of the environment. The name \code{default} is
 special; this is the environment that will be used by default
-(hence the name!).}
+(hence the name!).  Environment names can contain letters,
+numbers, hyphens and underscores.}
 
 \item{packages}{Packages to be \emph{attached} before starting a
 task. These will be loaded with \code{library()} before the \code{sources}

--- a/tests/testthat/test-bundle.R
+++ b/tests/testthat/test-bundle.R
@@ -36,6 +36,15 @@ test_that("bundles must have at least one id", {
 })
 
 
+test_that("bundle names must be filename-safe", {
+  path <- withr::local_tempdir()
+  init_quietly(path)
+  ids <- ids::random_id(3)
+  expect_error(hipercow_bundle_create(ids, name = "foo/bar", root = path),
+               "Invalid bundle name 'foo/bar'")
+})
+
+
 test_that("can control overwriting with 'overwrite' arg", {
   path <- withr::local_tempdir()
   init_quietly(path)

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -246,3 +246,29 @@ test_that("special value 'TRUE' triggers global environment build", {
   expect_match(res$messages[[1]], "Creating 'default' in a clean R session")
   expect_match(res$messages[[2]], "Found 1 symbol\\b")
 })
+
+
+test_that("can validate environment name on creation", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  expect_error(
+    hipercow_environment_create("empty", root = path),
+    "Can't create environment with special name 'empty'")
+  expect_error(
+    hipercow_environment_create("foo/bar", root = path),
+    "Invalid environment name 'foo/bar'")
+  expect_error(
+    hipercow_environment_create("", root = path),
+    "Invalid environment name ''")
+})
+
+
+test_that("can always load the empty environment", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  env <- environment_load("empty", root = root)
+  expect_equal(env$name, "empty")
+  expect_null(env$packages)
+  expect_null(env$sources)
+  expect_null(env$globals)
+})


### PR DESCRIPTION
Getting ahead of the inevitable saving of an environment or bundle with a `/`, `\` or `:` in it, which will fail badly.

Also adding in the idea of an "empty" environment, which comes from part of the rrq PR that I've paused until I get more of the rrq refactor finished