### PR TITLE
mrc-5058: allow unexported functions with task_create_call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/task-create.R
+++ b/R/task-create.R
@@ -636,6 +636,10 @@ check_function <- function(quo, call = NULL) {
     value <- NULL
     name <- as.character(expr[[3]])
     namespace <- as.character(expr[[2]])
+  } else if (rlang::is_call(expr, ":::")) {
+    value <- expr
+    name <- NULL
+    namespace <- NULL
   } else if (rlang::is_symbol(expr)) {
     envir <- rlang::quo_get_env(quo)
     name <- as.character(expr)

--- a/R/task-show.R
+++ b/R/task-show.R
@@ -1,6 +1,10 @@
 task_info_call_fn <- function(fn) {
   if (is.null(fn$name)) {
-    "(anonymous)"
+    if (rlang::is_call(fn$value, ":::")) {
+      deparse1(fn$value)
+    } else {
+      "(anonymous)"
+    }
   } else if (is.null(fn$namespace)) {
     fn$name
   } else {

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.2
+Version: 1.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-task-call.R
+++ b/tests/testthat/test-task-call.R
@@ -6,6 +6,14 @@ test_that("can resolve functions when call is namespaced", {
 })
 
 
+test_that("can resolve functions when call is non-exported", {
+  expect_mapequal(check_function(rlang::quo(ids:::toupper_initial)),
+                  list(name = NULL,
+                       namespace = NULL,
+                       value = quote(ids:::toupper_initial)))
+})
+
+
 test_that("can resolve function when function is in a package", {
   myfn <- ids::random_id
   expect_mapequal(check_function(rlang::quo(myfn)),
@@ -72,6 +80,20 @@ test_that("can run a task using a namespaced function", {
   msg <- capture_messages(print(task_info(id, root = path)))
   expect_match(msg, "Call: base::sqrt", all = FALSE, fixed = TRUE)
   expect_match(msg, "Args: 2", all = FALSE, fixed = TRUE)
+})
+
+
+test_that("can run a task using a non-exported function", {
+  path <- withr::local_tempdir()
+  init_quietly(path)
+  id <- withr::with_dir(path,
+                        task_create_call(ids:::toupper_initial, list("foo")))
+  expect_true(task_eval(id, root = path, verbose = FALSE))
+  expect_equal(task_result(id, root = path), "Foo")
+
+  msg <- capture_messages(print(task_info(id, root = path)))
+  expect_match(msg, "Call: ids:::toupper_initial", all = FALSE, fixed = TRUE)
+  expect_match(msg, 'Args: "foo"', all = FALSE, fixed = TRUE)
 })
 
 


### PR DESCRIPTION
I noticed this when porting the approach over to rrq, hopefully nothing that the users will do too much, but it can be useful