### PR TITLE
Better error for non-initialised root

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/root.R
+++ b/R/root.R
@@ -95,7 +95,7 @@ hipercow_root_find <- function(path) {
   path <- find_directory_descend("hipercow", start = path, limit = "/")
   if (length(path) == 0) {
     cli::cli_abort(
-      c("Couldn't find hipercow root.",
+      c("Couldn't find hipercow root",
         i = "Perhaps you need to run 'hipercow_init'"))
   }
   path_description <- file.path(path, "hipercow", "DESCRIPTION")

--- a/R/root.R
+++ b/R/root.R
@@ -93,6 +93,11 @@ hipercow_root <- function(root = NULL) {
 
 hipercow_root_find <- function(path) {
   path <- find_directory_descend("hipercow", start = path, limit = "/")
+  if (length(path) == 0) {
+    cli::cli_abort(
+      c("Couldn't find hipercow root.",
+        i = "Perhaps you need to run 'hipercow_init'"))
+  }
   path_description <- file.path(path, "hipercow", "DESCRIPTION")
   if (file.exists(path_description)) {
     d <- as.list(read.dcf(path_description)[1, ])

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.7
+Version: 1.0.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -48,7 +48,8 @@ test_that("avoid finding the hipercow package by default", {
 
 test_that("Error if root not found", {
   path <- withr::local_tempdir()
-  expect_error(hipercow_root(path))
+  expect_error(hipercow_root(path), 
+               "Couldn't find hipercow root.")
 })
 
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -48,7 +48,7 @@ test_that("avoid finding the hipercow package by default", {
 
 test_that("Error if root not found", {
   path <- withr::local_tempdir()
-  expect_error(hipercow_root(path), 
+  expect_error(hipercow_root(path),
                "Couldn't find hipercow root.")
 })
 


### PR DESCRIPTION
Fixes this:-

```
setwd("Q:/testcow")
# in a new folder - or one in which any hipercow folder is deleted

> hipercow::hipercow_provision()
Error in if (file.exists(path_description)) { : 
  argument is of length zero
```