### PR TITLE
Check for problematic code in environment

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.13
+Version: 1.0.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/environment.R
+++ b/R/environment.R
@@ -167,7 +167,7 @@ print.hipercow_environment <- function(x, ..., header = TRUE) {
 environment_load <- function(name, root, call = NULL) {
   path <- ensure_environment_exists(name, root, call)
   if (is.null(path)) {
-    new_environment(name, NULL, NULL, NULL, root)
+    new_environment(name, NULL, NULL, NULL, FALSE, root)
   } else {
     readRDS(path)
   }
@@ -261,7 +261,7 @@ discover_globals <- function(name, packages, sources, root) {
   res <- callr::r(function(name, packages, sources, path_root) {
     envir <- new.env(parent = topenv())
     root <- hipercow_root(path_root)
-    env <- new_environment(name, packages, sources, NULL, root)
+    env <- new_environment(name, packages, sources, NULL, FALSE, root)
     environment_apply(env, envir, root)
     names(envir)
   }, list(name, packages, sources, root$path$root), package = TRUE)

--- a/R/environment.R
+++ b/R/environment.R
@@ -29,6 +29,10 @@
 ##' @param overwrite On environment creation, replace an environment
 ##'   with the same name.
 ##'
+##' @param check Logical, indicating if we should check the source
+##'   files for issues.  Pass `FALSE` here if you need to bypass these
+##'   checks but beware the consequences that may await you.
+##'
 ##' @param root A hipercow root, or path to it. If `NULL` we search up
 ##'   your directory tree.
 ##'
@@ -55,7 +59,8 @@
 ##' cleanup()
 hipercow_environment_create <- function(name = "default", packages = NULL,
                                         sources = NULL, globals = NULL,
-                                        overwrite = TRUE, root = NULL) {
+                                        overwrite = TRUE, check = TRUE,
+                                        root = NULL) {
   root <- hipercow_root(root)
 
   assert_scalar_character(name)
@@ -65,7 +70,7 @@ hipercow_environment_create <- function(name = "default", packages = NULL,
   }
   check_safe_name_for_filename(name, "environment", rlang::current_env())
 
-  ret <- new_environment(name, packages, sources, globals,
+  ret <- new_environment(name, packages, sources, globals, check,
                          root, rlang::current_env())
 
   ## I did wonder about doing this by saving environment as:
@@ -185,7 +190,7 @@ ensure_environment_exists <- function(name, root, call = NULL) {
 }
 
 
-new_environment <- function(name, packages, sources, globals, root,
+new_environment <- function(name, packages, sources, globals, check, root,
                             call = NULL) {
   assert_scalar_character(name)
   if (!is.null(packages)) {
@@ -193,14 +198,29 @@ new_environment <- function(name, packages, sources, globals, root,
   }
   if (!is.null(sources)) {
     assert_character(sources)
-    err <- !file.exists(file.path(root$path$root, sources))
+    sources_full <- file.path(root$path$root, sources)
+    err <- !file.exists(sources_full)
     if (any(err)) {
       cli::cli_abort(
         c("File{?s} in 'sources' not found: {squote(sources[err])}",
           i = "Looking relative to '{root$path$root}'"),
         call = call)
     }
+    err <- fs::is_dir(sources_full)
+    if (any(err)) {
+      cli::cli_abort(
+        c(paste("File{?s} in 'sources' is a directory, not a file:",
+                "{squote(sources[err])}"),
+          i = "Looking relative to '{root$path$root}'",
+          i = paste("You cannot source a directory, only things that would be",
+                    "valid inputs to R's function 'source()'")),
+        call = call)
+    }
+    if (check) {
+      environment_check_sources(sources_full, call)
+    }
   }
+
   if (!is.null(globals)) {
     if (isTRUE(globals)) {
       globals <- discover_globals(name, packages, sources, root)
@@ -276,5 +296,25 @@ check_globals <- function(globals, envir, call = call) {
           "Disable this check at task creation by setting the option",
           "'hipercow.validate_globals' to FALSE")),
       call = call)
+  }
+}
+
+
+environment_check_sources <- function(paths, call = NULL) {
+  for (p in paths) {
+    used <- all.names(parse(file = p))
+    if ("install.packages" %in% used) {
+      cli::cli_abort(
+        c("Found call to 'install.packages()' in '{p}'",
+          "!" = paste("Don't call install.packages() from any code that you",
+                     "pass in as 'sources' when creating an environment.",
+                     "This makes your tasks much slower and will corrupt your",
+                     "library if you run more than one task at once"),
+          i = paste("If this is a false positive, you can pass 'check = FALSE'",
+                    "to 'hipercow_environment_create()' but it is probably",
+                    "safer to move your package installation code into",
+                    "another file")),
+        call = call)
+    }
   }
 }

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.13
+Version: 1.0.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/man/hipercow_environment.Rd
+++ b/man/hipercow_environment.Rd
@@ -14,6 +14,7 @@ hipercow_environment_create(
   sources = NULL,
   globals = NULL,
   overwrite = TRUE,
+  check = TRUE,
   root = NULL
 )
 
@@ -52,6 +53,10 @@ enabled by default).}
 
 \item{overwrite}{On environment creation, replace an environment
 with the same name.}
+
+\item{check}{Logical, indicating if we should check the source
+files for issues.  Pass \code{FALSE} here if you need to bypass these
+checks but beware the consequences that may await you.}
 
 \item{root}{A hipercow root, or path to it. If \code{NULL} we search up
 your directory tree.}

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -327,7 +327,7 @@ test_that("can check contents of sources", {
   path <- withr::local_tempfile()
   root <- init_quietly(path)
   writeLines("install.packages('whatever')", file.path(path, "src.R"))
-  err <- expect_error(
+  expect_error(
     environment_check_sources(file.path(path, "src.R")),
     "Found call to 'install.packages()' in",
     fixed = TRUE)
@@ -339,7 +339,7 @@ test_that("can check contents of sources", {
                     globals = NULL,
                     check = TRUE,
                     root = root),
-    err$message,
+    "Found call to 'install.packages()' in",
     fixed = TRUE)
 })
 

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -342,3 +342,20 @@ test_that("can check contents of sources", {
     err$message,
     fixed = TRUE)
 })
+
+
+test_that("warn about directories instead of files in sources", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  writeLines("TRUE", file.path(path, "src.R"))
+  dir.create(file.path(path, "other"))
+  expect_error(
+    new_environment("foo",
+                    packages = NULL,
+                    sources = c("src.R", "other"),
+                    globals = NULL,
+                    check = TRUE,
+                    root = root),
+    "File in 'sources' is a directory, not a file: 'other'",
+    fixed = TRUE)
+})

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -150,7 +150,6 @@ previously submitted gets run (which could happen ages after you
 submit it if the cluster is busy).
 
 ```{r}
-hipercow_environment_create(sources = "mycode.R")
 id <- task_create_expr(times2(10))
 task_wait(id)
 task_status(id)


### PR DESCRIPTION
This PR adds a check for problematic code in sources used for the environment creation.  At the moment this is limited to `install.packages()` but we might want to grow this over time (and perhaps have warnings about use of `library()` for example).