### PR TITLE
Load environment variables at the start of the tasks' process.

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -8,4 +8,5 @@ RESULT <- "result"
 DATA <- "data"
 INFO <- "info"
 RESOURCES <- "resources"
+RENVIRON <- "Renviron"
 # nolint end

--- a/R/envvars.R
+++ b/R/envvars.R
@@ -143,3 +143,12 @@ envvars_apply <- function(envvars, envir) {
   env <- set_names(envvars$value, envvars$name)
   withr::local_envvar(env, .local_envir = envir)
 }
+
+envvars_export <- function(envvars, path) {
+  if (!is.null(envvars)) {
+    vars <- envvars[!envvars$secret,]
+    writeLines(sprintf("%s=%s", vars$name, vars$value), path)
+  } else {
+    file.create(path)
+  }
+}

--- a/R/task-create.R
+++ b/R/task-create.R
@@ -531,8 +531,23 @@ task_create_bulk_call <- function(fn, data, args = NULL,
 }
 
 
+task_export_envvars <- function(root, dst, envvars, inherit_envvars) {
+  if (is.null(inherit_envvars)) {
+    envvars_export(envvars, dst)
+  } else {
+    src <- file.path(path_task(root$path$tasks, inherit_envvars), RENVIRON)
+    if (fs::file_exists(src)) {
+      fs::file_copy(src, dst)
+    } else {
+      fs::file_create(dst)
+    }
+  }
+}
+
+
 task_create <- function(root, type, path, environment, envvars,
-                        parallel, ..., id = ids::random_id()) {
+                        parallel, ..., id = ids::random_id(),
+                        inherit_envvars = NULL) {
   time <- Sys.time()
   dest <- path_task(root$path$tasks, id)
   fs::dir_create(dest)
@@ -540,6 +555,8 @@ task_create <- function(root, type, path, environment, envvars,
                path = path, environment = environment, envvars = envvars,
                parallel = parallel, ...)
   saveRDS(data, file.path(dest, DATA))
+  task_export_envvars(root, file.path(dest, RENVIRON), envvars, inherit_envvars)
+
   id
 }
 

--- a/R/task-retry.R
+++ b/R/task-retry.R
@@ -82,7 +82,8 @@ task_retry <- function(id, driver = NULL, resources = NULL, root = NULL) {
   id_base <- base_retry_map(id_real, root)
   id_new <- vcapply(seq_along(id), function(i) {
     task_create(root, "retry", NULL, NULL, NULL, NULL,
-                parent = id_real[[i]], base = id_base[[i]])
+                parent = id_real[[i]], base = id_base[[i]],
+                inherit_envvars = id_base[[i]])
   })
 
   update_retry_map(id_new, id_real, id_base, root)

--- a/drivers/windows/inst/templates/task_run.bat
+++ b/drivers/windows/inst/templates/task_run.bat
@@ -16,6 +16,7 @@ cd {{hipercow_root_path}}
 ECHO working directory: %CD%
 
 set R_LIBS_USER={{hipercow_library}}
+set R_ENVIRON_USER=hipercow\tasks\{{task_id_1}}\{{task_id_2}}\Renviron
 set HIPERCOW_NO_DRIVERS=1
 set RENV_AUTOLOADER_ENABLED=FALSE
 set HIPERCOW_CORES=%CCP_NUMCPUS%

--- a/tests/testthat/test-envvars.R
+++ b/tests/testthat/test-envvars.R
@@ -127,3 +127,24 @@ test_that("error if user tries to use encrypted envvars without driver", {
     prepare_envvars(e, NULL, root),
     "No driver selected, so cannot work with secret environment variables")
 })
+
+
+test_that("environment variables can be exported", {
+  path <- withr::local_tempfile()
+
+  e <- hipercow_envvars(A = "x", B = "y")
+
+  envvars_export(e, path)
+  expect_equal(readLines(path), c("A=x", "B=y"))
+})
+
+
+test_that("secret environment variables are not exported", {
+  path <- withr::local_tempfile()
+
+  e <- c(hipercow_envvars(A = "x"),
+         hipercow_envvars(B = "y", secret = TRUE))
+
+  envvars_export(e, path)
+  expect_equal(readLines(path), c("A=x"))
+})

--- a/tests/testthat/test-task-retry.R
+++ b/tests/testthat/test-task-retry.R
@@ -171,3 +171,19 @@ test_that("don't add retry element when not wanted", {
   expect_equal(task_info(id1, root = path)$retry_chain, c(id1, id2))
   expect_null(task_info(id3, root = path)$retry_chain)
 })
+
+
+test_that("Retried task inherits exported envvars", {
+  path <- withr::local_tempdir()
+  init_quietly(path)
+
+  envvars <- hipercow_envvars(MY_ENVVAR = "hello")
+
+  id1 <- withr::with_dir(path, {
+    task_create_explicit(quote(runif(1)), envvars=envvars)
+  })
+  expect_true(task_eval(id1, root = path))
+
+  id2 <- task_retry(id1, root = path)
+  expect_equal(readLines(path_to_task_file(path, id2, "Renviron")), "MY_ENVVAR=hello")
+})

--- a/tests/testthat/test-task.R
+++ b/tests/testthat/test-task.R
@@ -589,8 +589,13 @@ test_that("can run a task with envvars", {
   envvar <- hipercow_envvars(TEST_ENV = "hello!")
   id <- withr::with_dir(
     path, task_create_expr(Sys.getenv("TEST_ENV"), envvars = envvar))
+
   dat <- readRDS(path_to_task_file(path, id, "data"))
   expect_equal(dat$envvars, envvar)
+
+  renviron <- readLines(path_to_task_file(path, id, "Renviron"))
+  expect_equal(readLines(path), c("TEST_ENV=hello!"))
+
   expect_true(task_eval(id, root = path))
   expect_equal(task_result(id, root = path), "hello!")
   expect_equal(Sys.getenv("TEST_ENV"), "")


### PR DESCRIPTION
There are environment variables that control the behaviour of the R interpreter, such as tuning the GC. These variables must be set at the start at the process. Setting them from R code, as we do now, is too late and has no effect.

This commit exports all non-secret environment variables into an Renviron file in the task directory, which the batch script configures using R_ENVIRON_USER. Once of the first things the R interpreter does is load that file and set values it finds as environment variables.

The existing mechanism to load environment variables is kept. It is necessary both to support secret variables, which we don't want to expose in the Renviron, and to allow tasks to run without starting a new process at all, as is commonly done in tests and in the example driver.

Retry tasks need a bit of care for this to work as well. For the most part, the new task's folder only contains an indirection to the original task's data and not a copy of it. When the task starts, it follows the indirection to find the actual data. This strategy does not work for the Renviron file, so a copy of that file is made.