### PR TITLE
Check that driver and main package are compatible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.15
+Version: 1.0.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.15
+Version: 1.0.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/check.R
+++ b/drivers/windows/R/check.R
@@ -3,6 +3,7 @@ windows_check <- function(path = getwd(), call = NULL) {
   ok <- windows_check_connection() && ok
   ok <- windows_check_path(path) && ok
   ok <- windows_check_project(path) && ok
+  ok <- windows_check_versions() && ok
   invisible(ok)
 }
 
@@ -114,4 +115,33 @@ windows_check_project <- function(path) {
       FALSE
     }
   }
+}
+
+
+## If this gets annoying we should probably do some clever versioning
+## where we ignore patch numbers for this comparison (quite easy to
+## do).
+windows_check_versions <- function(v_hipercow = hipercow_version(),
+                                   v_windows = hipercow_windows_version(),
+                                   report_failure_only = FALSE) {
+  if (v_hipercow == v_windows) {
+    if (!report_failure_only) {
+      cli::cli_alert_success(
+        "'hipercow' and 'hipercow.windows' versions agree ({v_hipercow})")
+    }
+    return(TRUE)
+  }
+  cli::cli_alert_danger(
+    paste("Your 'hipercow' ({v_hipercow}) and",
+          "'hipercow.windows' ({v_windows}) versions differ"))
+  cli::cli_alert_info(
+    "You should install both again, in a fresh R session by running:")
+  cmd <- paste(
+    "install.packages(",
+    '    c("hipercow", "hipercow.windows"),',
+    '    repos = c("https://mrc-ide.r-universe.dev",',
+    '              "https://cloud.r-project.org"))',
+    sep = "\n")
+  cli::cli_alert(gsub(" ", "\u00a0", cmd))
+  FALSE
 }

--- a/drivers/windows/R/util.R
+++ b/drivers/windows/R/util.R
@@ -99,7 +99,7 @@ hipercow_version <- function() {
 hipercow_windows_version <- function() {
   if (is.null(cache$hipercow_windows_version)) {
     cache$hipercow_windows_version <-
-      as.character(utils::packageVersion("hipercow"))
+      as.character(utils::packageVersion("hipercow.windows"))
   }
   cache$hipercow_windows_version
 }

--- a/drivers/windows/R/zzz.R
+++ b/drivers/windows/R/zzz.R
@@ -1,6 +1,16 @@
 cache <- new.env(parent = emptyenv())
 
 
+.onLoad <- function(...) {
+  # nocov start
+  if (nzchar(Sys.getenv("DEVTOOLS_LOAD"))) {
+    return()
+  }
+  windows_check_versions(report_failure_only = TRUE)
+  # nocov end
+}
+
+
 .onAttach <- function(...) {
   # nocov start
   if (nzchar(Sys.getenv("DEVTOOLS_LOAD"))) {

--- a/drivers/windows/tests/testthat/test-util.R
+++ b/drivers/windows/tests/testthat/test-util.R
@@ -145,3 +145,34 @@ test_that("menu copes better than utils::menu with cancel", {
   expect_equal(menu(c("cancel", "other", "another")), "other")
   expect_equal(menu(c("cancel", "other", "another")), "another")
 })
+
+
+test_that("can check package versions", {
+  cache$hipercow_version <- NULL
+  cache$hipercow_windows_version <- NULL
+  on.exit({
+    cache$hipercow_version <- NULL
+    cache$hipercow_windows_version <- NULL
+  })
+  mock_package_version <- mockery::mock(
+    numeric_version("1.2.3"), numeric_version("2.3.4"))
+  mockery::stub(hipercow_version, "utils::packageVersion",
+                mock_package_version)
+  mockery::stub(hipercow_windows_version, "utils::packageVersion",
+                mock_package_version)
+
+  expect_equal(hipercow_version(), "1.2.3")
+  mockery::expect_called(mock_package_version, 1)
+  expect_equal(mockery::mock_args(mock_package_version)[[1]], list("hipercow"))
+
+  expect_equal(hipercow_version(), "1.2.3")
+  mockery::expect_called(mock_package_version, 1)
+
+  expect_equal(hipercow_windows_version(), "2.3.4")
+  mockery::expect_called(mock_package_version, 2)
+  expect_equal(
+    mockery::mock_args(mock_package_version)[[2]], list("hipercow.windows"))
+
+  expect_equal(hipercow_windows_version(), "2.3.4")
+  mockery::expect_called(mock_package_version, 2)
+})


### PR DESCRIPTION
We've hit issues where this was not obvious; now we check at startup and print instructions if people are in danger.  We might want to relax this in future.