### PR TITLE
Check that versions are new enough

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.16
+Version: 1.0.17
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.16
+Version: 1.0.17
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/bootstrap.R
+++ b/drivers/windows/R/bootstrap.R
@@ -17,8 +17,9 @@ bootstrap_update <- function(development = NULL, root = NULL) {
 }
 
 
-bootstrap_update_all <- function(development = NULL, root = NULL) {
-  versions <- recent_versions()
+bootstrap_update_all <- function(development = NULL, root = NULL,
+                                 versions = r_versions()) {
+  versions <- recent_versions(versions)
   for (i in seq_along(versions)) {
     version <- versions[[i]]
     cli::cli_alert_info("Setting up bootstrap for R {version}")
@@ -30,7 +31,6 @@ bootstrap_update_all <- function(development = NULL, root = NULL) {
 
 
 recent_versions <- function(versions = r_versions()) {
-  versions <- r_versions()
   v <- max(versions)
   v[[c(1, 3)]] <- 0
   v[[c(1, 2)]] <- as.integer(v[[c(1, 2)]]) - 1

--- a/drivers/windows/R/config.R
+++ b/drivers/windows/R/config.R
@@ -12,9 +12,10 @@ windows_configure <- function(shares = NULL, r_version = NULL) {
 }
 
 
-select_r_version <- function(r_version, ours = getRversion()) {
-  if (is.null(r_version)) {
-    valid <- r_versions()
+select_r_version <- function(r_version, ours = getRversion(),
+                             valid = r_versions()) {
+  select_by_match <- is.null(r_version)
+  if (select_by_match) {
     if (ours %in% valid) {
       r_version <- numeric_version(ours)
     } else {
@@ -26,9 +27,48 @@ select_r_version <- function(r_version, ours = getRversion()) {
     if (is.character(r_version)) {
       r_version <- numeric_version(r_version)
     }
-    if (!(r_version %in% r_versions())) {
+    if (!(r_version %in% valid)) {
       stop("Unsupported R version: ", as.character(r_version))
     }
   }
+
+  check_old_versions(valid, r_version, ours)
+
   r_version
+}
+
+
+check_old_versions <- function(valid, selected, ours) {
+  ## So we have a set of versions, and we want to know how many minor
+  ## versions behind they are:
+  series <- valid[, -3]
+  age <- match(series, rev(unique(series))) - 1
+
+  age_selected <- age[match(selected[, -3], series)]
+  age_ours <- age[match(ours[, -3], series)]
+  current <- max(valid)
+
+  if (age_selected > 1) {
+    cli::cli_alert_warning(
+      "Selected an old R version '{selected}' to use on the cluster")
+    cli::cli_alert_info(paste(
+      "The version that you have selected to run on the cluster is now",
+      "more than 1 minor version old, which means that it no longer has",
+      "new builds of binary packages on CRAN.  This means provisioning",
+      "will be slow and eventually will fail."))
+    cli::cli_alert_info(paste(
+      "The minimum recommended version is '{min(valid[age <= 1])}' and",
+      "the most recent supported version is '{current}'"))
+    cmd <- sprintf('hipercow_configure("windows", r_version = "%s")', current)
+    cli::cli_alert_info(paste(
+      "You can select a newer R version on the cluster without affecting",
+      "your local installation by running '{nonbreaking(cmd)}'"))
+  }
+
+  is_old <- ours < current && (is.na(age_ours) || age_ours > 2)
+  if (is_old) {
+    cli::cli_alert_warning(paste(
+      "Your {.strong local} R installation is very old ('{ours}');",
+      "you should upgrade it!"))
+  }
 }

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -6,6 +6,7 @@ windows_provision_run <- function(args, config, path_root) {
   args$poll <- NULL
 
   client <- get_web_client()
+  check_old_versions(r_versions(), config$r_version, getRversion())
   check_running_before_install(client, path_root = path_root)
 
   conan_config <- rlang::inject(conan2::conan_configure(

--- a/drivers/windows/R/util.R
+++ b/drivers/windows/R/util.R
@@ -172,3 +172,8 @@ menu <- function(choices, cancel = choices[[1]]) {
   idx <- utils::menu(choices)
   if (idx == 0) cancel else choices[[idx]]
 }
+
+
+nonbreaking <- function(x) {
+  gsub(" ", "\u00a0", x)
+}

--- a/drivers/windows/tests/testthat/helper-hipercow.R
+++ b/drivers/windows/tests/testthat/helper-hipercow.R
@@ -1,2 +1,3 @@
 ## Ensures that tests work if offline
-cache$r_versions <- numeric_version(c("4.0.5", "4.1.3", "4.2.3", "4.3.0"))
+cache$r_versions <- numeric_version(
+  c("4.2.3", "4.3.0", "4.3.2", "4.3.3", "4.4.0"))

--- a/drivers/windows/tests/testthat/test-bootstrap.R
+++ b/drivers/windows/tests/testthat/test-bootstrap.R
@@ -63,11 +63,15 @@ test_that("can find recent versions", {
 test_that("bootstrap iterates through correct versions", {
   mock_update <- mockery::mock()
   mock_init <- mockery::mock()
+  mock_versions <- mockery::mock(
+    numeric_version(c("4.0.5", "4.1.3", "4.2.3", "4.3.0")))
   mockery::stub(bootstrap_update_all, "bootstrap_update", mock_update)
   mockery::stub(bootstrap_update_all, "hipercow::hipercow_init", mock_init)
+  mockery::stub(bootstrap_update_all, "r_versions", mock_versions)
 
   suppressMessages(bootstrap_update_all())
 
+  mockery::expect_called(mock_versions, 1)
   mockery::expect_called(mock_init, 2)
   expect_equal(
     mockery::mock_args(mock_init)[[1]],

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -19,14 +19,16 @@ test_that("Can create configuration", {
 
 
 test_that("Select a sensible r version", {
-  v <- r_versions()
-  vmax <- max(v)
-  vmid <- v[length(v) - 3]
-  expect_equal(select_r_version(vmax), vmax)
-  expect_error(select_r_version("3.6.0"),
+  v <- numeric_version(c("4.0.5", "4.1.3", "4.2.3", "4.3.0"))
+  vmax <- numeric_version("4.3.0")
+  vmid <- numeric_version("4.2.3")
+  expect_equal(select_r_version(vmax, valid = v), vmax)
+  expect_error(select_r_version(numeric_version("3.6.0"), valid = v),
                "Unsupported R version: 3.6.0")
-  expect_equal(select_r_version(NULL, vmid), vmid)
-  expect_equal(select_r_version(NULL, "4.1.0"), numeric_version("4.1.3"))
+  expect_equal(select_r_version(NULL, ours = vmid, valid = v), vmid)
+  expect_equal(
+    select_r_version(NULL, ours = numeric_version("4.2.0"), valid = v),
+    numeric_version("4.2.3"))
 })
 
 
@@ -43,4 +45,38 @@ test_that("can configure a root", {
                                  r_version = "4.3.0",
                                  root = root))
   expect_equal(root$config$windows, cmp)
+})
+
+
+test_that("can warn about old R versions", {
+  valid <- numeric_version(
+    c("4.2.3", "4.3.0", "4.3.2", "4.3.3", "4.4.0"))
+  current <- numeric_version("4.4.0")
+  ok <- numeric_version("4.3.2")
+  old <- numeric_version("4.2.3")
+  ancient <- numeric_version("4.1.3")
+
+  expect_silent(
+    check_old_versions(valid, current, current))
+  expect_silent(
+    check_old_versions(valid, ok, ok))
+  expect_silent(
+    check_old_versions(valid, ok, old))
+
+  res <- evaluate_promise(check_old_versions(valid, old, old))
+  expect_length(res$messages, 4)
+  expect_match(
+    res$messages[[1]],
+    "Selected an old R version '4.2.3'")
+  expect_match(
+    res$messages[[3]],
+    "minimum recommended version is '4.3.0'")
+  expect_match(res$messages[[4]], "4.4.0", fixed = TRUE)
+
+  res2 <- evaluate_promise(check_old_versions(valid, old, ancient))
+  expect_length(res2$messages, 5)
+  expect_equal(res2$messages[1:4], res$messages)
+  expect_match(
+    res2$messages[[5]],
+    "Your local R installation is very old")
 })


### PR DESCRIPTION
Checks on configure and provision that the versions used are not too old; too old is older than r-oldrel, at which point packages are hard to install.  We don't check this on use because at that point things should continue to work reasonably well.

The provided message is fairly gory but hopefully clear enough, and points people in the right direction. It can't be silenced easily so hopefully people will upgrade