### PR TITLE
Remove duplicated processing of arguments in rrq setup.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.18
+Version: 1.0.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -95,8 +95,6 @@ hipercow_rrq_workers_submit <- function(n,
   driver <- hipercow_driver_select(driver, TRUE, root, call)
   r <- rrq_prepare(driver, root, call = call)
 
-  resources <- resources_validate(resources, driver, root)
-  envvars <- prepare_envvars(envvars, driver, root, call)
   progress <- show_progress(progress, call)
   timeout <- timeout_value(timeout, call)
 

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.18
+Version: 1.0.19
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -174,8 +174,8 @@ test_that("can submit workers with envvars", {
 
   launch_example_workers(path)
 
-  e1 <- hipercow_envvars(X="foo")
-  e2 <- hipercow_envvars(Y="bar", secret=TRUE)
+  e1 <- hipercow_envvars(X = "foo")
+  e2 <- hipercow_envvars(Y = "bar", secret = TRUE)
   envvars <- c(e1, e2)
 
   expect_message(
@@ -183,7 +183,7 @@ test_that("can submit workers with envvars", {
     "Created new rrq queue")
   suppressMessages(
     info <- withr::with_dir(path,
-      hipercow_rrq_workers_submit(1, envvars=envvars)))
+      hipercow_rrq_workers_submit(1, envvars = envvars)))
 
   id <- rrq::rrq_task_create_expr(Sys.getenv("X"))
   expect_true(rrq::rrq_task_wait(id))


### PR DESCRIPTION
The `hipercow_rrq_workers_submit` function was doing some processing of its resources and envvars arguments before passing them to `task_create_bulk_call`. The latter applied the exact same processing to these arguments.

For the most part, the processing is idempotent and only seeks to validate the inputs, so this only had a limited impact. The only exception is the encryption of secret variables, which was done twice, leading to undesirable behaviour.

Somehow the second encryption was failing rather than just performing a second layer of encryption. I think our use of the encryption routines has an upper limit on the size of payloads, and the outcome of the first round is larger than that limit. Regardless, we shouldn't be calling the encryption code twice, even if it had worked we would only decrypt once and not get back the correct value.