### PR TITLE
Fix the path to the status file in the batch file.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.20
+Version: 1.0.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.20
+Version: 1.0.21
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/inst/templates/task_run.bat
+++ b/drivers/windows/inst/templates/task_run.bat
@@ -47,7 +47,7 @@ if %ErrorCodeTask% neq 0 (
   EXIT /b %ErrorCodeTask%
 )
 
-if exist hipercow\tasks\{{task_id_1}}\{{task_id_2}}\log\status-success (
+if exist hipercow\tasks\{{task_id_1}}\{{task_id_2}}\status-success (
   ECHO Task completed successfully!
   ECHO Quitting
 ) else (

--- a/drivers/windows/inst/templates/task_run.bat
+++ b/drivers/windows/inst/templates/task_run.bat
@@ -31,6 +31,12 @@ Rscript -e "hipercow::task_eval('{{task_id}}', verbose = TRUE)" > "hipercow\task
 @ECHO off
 set ErrorCodeTask=%ERRORLEVEL%
 
+if exist hipercow\tasks\{{task_id_1}}\{{task_id_2}}\status-success (
+  set TaskStatus=0
+) else (
+  set TaskStatus=1
+)
+
 ECHO ERRORLEVEL was %ErrorCodeTask%
 
 ECHO Cleaning up
@@ -40,14 +46,12 @@ ECHO Cleaning up
 
 net use I: /delete /y
 
-set ERRORLEVEL=%ErrorCodeTask%
-
 if %ErrorCodeTask% neq 0 (
   ECHO Task failed catastrophically
   EXIT /b %ErrorCodeTask%
 )
 
-if exist hipercow\tasks\{{task_id_1}}\{{task_id_2}}\status-success (
+if %TaskStatus% == 0 (
   ECHO Task completed successfully!
   ECHO Quitting
 ) else (


### PR DESCRIPTION
The batch file to run tasks checks for the presence of a `status-success` file when exiting, and derives its exit code from that. This is done to report useful status on the HPC web portal.

Unfortunately the path it was looking for was incorrect, therefore the file never existed and all jobs are reported as failed. This fixes the path by removing a spurious `log\` component.