### PR TITLE
Use as.numeric_version in bootstrap

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.25
+Version: 1.0.26
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.25
+Version: 1.0.26
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/bootstrap.R
+++ b/drivers/windows/R/bootstrap.R
@@ -19,7 +19,7 @@ bootstrap_update <- function(development = NULL, root = NULL) {
 
 bootstrap_update_all <- function(development = NULL, root = NULL,
                                  versions = r_versions()) {
-  versions <- recent_versions(versions)
+  versions <- recent_versions(as.numeric_version(versions))
   for (i in seq_along(versions)) {
     version <- versions[[i]]
     cli::cli_alert_info("Setting up bootstrap for R {version}")


### PR DESCRIPTION
Tiny PR, for where I wanted to run 
```
hipercow.windows:::bootstrap_update_all(versions = "4.4.1")
```
but had to write:
```
hipercow.windows:::bootstrap_update_all(versions = as.numeric_version("4.4.1"))
```
