### PR TITLE
Print environment contents when loading it.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.26
+Version: 1.0.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/environment.R
+++ b/R/environment.R
@@ -238,11 +238,15 @@ new_environment <- function(name, packages, sources, globals, check, root,
 }
 
 
-environment_apply <- function(name, envir, root, call = NULL) {
+environment_apply <- function(name, envir, root, call = NULL, verbose = FALSE) {
   if (is.list(name)) {
     env <- name
   } else {
     env <- environment_load(name, root, call)
+  }
+  if (verbose && (length(env$packages) > 0 || length(env$sources) > 0)) {
+    cli::cli_alert_info("Loading environment '{env$name}'...")
+    print(env, header = FALSE)
   }
   for (p in env$packages) {
     library(p, character.only = TRUE)

--- a/R/task-eval.R
+++ b/R/task-eval.R
@@ -38,7 +38,7 @@ task_eval <- function(id, envir = .GlobalEnv, verbose = FALSE, root = NULL) {
     version <- utils::packageVersion("hipercow")
     cli::cli_h1("hipercow {version} running at '{root$path$root}'")
     cli::cli_alert_info("library paths:")
-    cli::cli_li(.libPaths())
+    cli::cli_ul(.libPaths())
     cli::cli_alert_info("id: {id}")
     cli::cli_alert_info("starting at: {t0}")
   }
@@ -75,7 +75,8 @@ task_eval <- function(id, envir = .GlobalEnv, verbose = FALSE, root = NULL) {
       hipercow_rrq_controller(set_as_default = TRUE, root = root)
     }
 
-    environment_apply(data$environment, envir, root, top)
+    environment_apply(data$environment, envir, root, top, verbose)
+
     if (!is.null(data$parallel)) {
       hipercow_parallel_setup(data$parallel)
     }

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.26
+Version: 1.0.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -359,3 +359,19 @@ test_that("warn about directories instead of files in sources", {
     "File in 'sources' is a directory, not a file: 'other'",
     fixed = TRUE)
 })
+
+
+test_that("Can be verbose when applying an environment", {
+  path <- withr::local_tempfile()
+  root <- init_quietly(path)
+  writeLines("a <- 1", file.path(path, "a.R"))
+
+  suppressMessages(hipercow_environment_create("foo", packages = "base",
+                                               sources = "a.R", root = path))
+
+  env <- new.env()
+  res <- evaluate_promise(environment_apply("foo", env, root, verbose = TRUE))
+  expect_match(res$messages, "packages: base", all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "sources: a.R", all = FALSE, fixed = TRUE)
+  expect_match(res$messages, "globals: (none)", all = FALSE, fixed = TRUE)
+})


### PR DESCRIPTION
hipercow silently attaches packages and sources files from the configured environment. If something goes wrong in this process (eg. the file does not exist), it can be difficult for users to understand what is happening. None of their own code makes any mention of the files or packages in question, and they may have forgotten that they ever created the environment.

This prints a message when loading the environment, with the list of files and packages that will be loaded. This should provide enough hints for the user to make the connection between a hypothetical error and the environment.