### PR TITLE
Never fail when looking up windows username fails when fetching configuration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.32
+Version: 1.0.33
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -83,7 +83,15 @@ configuration_drivers <- function(root) {
     ## because it's useful to report, and this is where we'd want it
     ## reported. We could add this into the configuration itself, but
     ## that causes some pain for the testing there.
-    ret$windows$username <- windows_username()
+    ret$windows$username <- tryCatch(
+      windows_username(),
+      error = function(e) {
+        cli::cli_warn(
+               c("Failed to read windows username",
+                 i = "Try 'windows_username()' to reproduce separately"),
+               parent = e)
+        "(???)"
+      })
   }
   ret
 }

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.32
+Version: 1.0.33
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),


### PR DESCRIPTION
Small one here, which bit us when diagnosing a problem for a cluster user a few weeks/months ago - see ticket for details.
