### PR TITLE
Use an absolute path for R_LIBS_USER and R_ENVIRON_USER.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.33
+Version: 1.0.34
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.33
+Version: 1.0.34
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/paths.R
+++ b/drivers/windows/R/paths.R
@@ -68,7 +68,7 @@ print.windows_path <- function(x, ...) {
 
 remote_path <- function(x, shares) {
   x <- prepare_path(x, shares)
-  windows_path_slashes(file.path(x$path_remote, x$rel, fsep = "/"))
+  file.path(x$drive_remote, x$rel)
 }
 
 

--- a/drivers/windows/inst/templates/task_run.bat
+++ b/drivers/windows/inst/templates/task_run.bat
@@ -16,7 +16,7 @@ cd {{hipercow_root_path}}
 ECHO working directory: %CD%
 
 set R_LIBS_USER={{hipercow_library}}
-set R_ENVIRON_USER=hipercow\tasks\{{task_id_1}}\{{task_id_2}}\Renviron
+set R_ENVIRON_USER={{renviron_path}}
 set HIPERCOW_NO_DRIVERS=1
 set RENV_AUTOLOADER_ENABLED=FALSE
 set HIPERCOW_CORES=%CCP_NUMCPUS%

--- a/drivers/windows/tests/testthat/test-batch.R
+++ b/drivers/windows/tests/testthat/test-batch.R
@@ -4,7 +4,7 @@ test_that("batch data creates entries for share drives", {
   path_root <- root$path$root
 
   config <- root$config$windows
-  dat <- template_data(config, path_root)
+  dat <- template_data_common(config, path_root)
 
   nms <- c("hostname",
            "date",
@@ -15,7 +15,6 @@ test_that("batch data creates entries for share drives", {
            "network_shares_delete",
            "hipercow_root_drive",
            "hipercow_root_path",
-           "hipercow_library",
            "cluster_name")
   expect_setequal(names(dat), nms)
   expect_true(all(vlapply(dat, function(x) is.character(x) && length(x) == 1)))
@@ -24,10 +23,28 @@ test_that("batch data creates entries for share drives", {
 
   expect_equal(dat$hipercow_root_drive, "X:")
   expect_equal(dat$hipercow_root_path, "\\b\\c")
+})
+
+
+test_that("batch data uses absolute paths", {
+  mount <- withr::local_tempfile()
+  root <- example_root(mount, "b/c")
+  path_root <- root$path$root
+
+  config <- root$config$windows
+  id <- withr::with_dir(
+    path_root,
+    hipercow::task_create_explicit(quote(sessionInfo()), driver = FALSE))
+  dat <- template_data_task_run(id, config, path_root)
 
   v <- version_string(config$r_version, ".")
-  expected <- sprintf("hipercow/lib/windows/%s;I:/bootstrap/%s", v, v)
+  expected <- sprintf("X:/b/c/hipercow/lib/windows/%s;I:/bootstrap/%s", v, v)
   expect_equal(dat$hipercow_library, expected)
+
+  expected <- sprintf("X:/b/c/hipercow/tasks/%s/%s/Renviron",
+                      substr(id, 1, 2),
+                      substr(id, 3, nchar(id)))
+  expect_equal(dat$renviron_path, expected)
 })
 
 
@@ -36,10 +53,8 @@ test_that("batch data can run from subdirectory of root", {
   root <- example_root(mount, "b/c")
   path_root <- root$path$root
   config <- root$config$windows
-  path <- file.path(mount, "b/c/d")
-  fs::dir_create(path)
-  path <- normalize_path(path)
-  dat <- template_data(config, path_root)
+
+  dat <- template_data_common(config, path_root)
   expect_equal(dat$hipercow_root_drive, "X:")
   expect_equal(dat$hipercow_root_path, "\\b\\c")
 })

--- a/drivers/windows/tests/testthat/test-paths.R
+++ b/drivers/windows/tests/testthat/test-paths.R
@@ -97,10 +97,14 @@ test_that("Can create a remote path", {
   shares <- list(
     home = windows_path(p, "//fi--san03/homes/bob", "Q:"),
     temp = windows_path(tempdir(), "//fi--san03/tmp", "T:"))
+
   res <- remote_path(t, shares)
-  expect_equal(
-    res,
-    paste0("\\\\fi--san03.dide.ic.ac.uk\\tmp\\", basename(t)))
+  expect_equal(res, paste0("T:/", basename(t)))
+
+  d <- file.path(t, "foo", "bar")
+  fs::dir_create(d)
+  res <- remote_path(d, shares)
+  expect_equal(res, paste0("T:/", basename(t), "/foo/bar"))
 })
 
 


### PR DESCRIPTION
At present, the R_LIBS_USER path embedded in the batch file is relative to the working directory in which R is spawned. This generally works fine.

However, if the user's task switches working directories and then spawns a new R interpreter, then the new session will not be able to resolve the R_LIBS_USER anymore and the user's provisioned library won't be found.

This was an issue when a user was running an orderly task, which switches working directories to a draft folder, and then uses the parallel package, which spawns new R processes. Note that this is only an issue when users create their own clusters and not when using the builtin hipercow parallel support, since the latter explicitly inherits the libPaths.

By making the path absolute it now works regardless of which working directory the new R processes are spawned.

This also changes R_ENVIRON_USER for the same reasons. You could argue that sub-processes should not reload that file anyway, since they inherit the environment variables directly already. However if we did want that behaviour it should be done separately and consistently, probably by unsetting R_ENVIRON_USER, and not just happen to be the case when the working directory is modified.