### PR TITLE
Allow rrq tasks to be started from a hipercow task.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.34
+Version: 1.0.35
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -331,6 +331,8 @@ parallel_validate <- function(parallel, cores, environment, driver, root,
           i = "Use 'hipercow_rrq_controller()' to configure rrq first"),
         call = call)
     }
+
+    parallel$rrq_queue_id <- readLines(path_queue)
   }
 
   parallel

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -20,16 +20,20 @@
 ##' @param set_as_default Set the rrq controller to be the default;
 ##'   this is usually what you want.
 ##'
+##' @param queue_id The rrq queue id to use. You shouldn't need to pass a value
+##'   for this: the queue id can be found from the hipercow state directory, or
+##'   a new one is created if needed.
+##'
 ##' @inheritParams task_create_expr
 ##'
 ##' @return An [rrq::rrq_controller] object.
 ##'
 ##' @export
 hipercow_rrq_controller <- function(..., set_as_default = TRUE, driver = NULL,
-                                    queue_id = NA, root = NULL) {
+                                    queue_id = NULL, root = NULL) {
   root <- hipercow_root(root)
   call <- rlang::current_env()
-  if (is.na(queue_id)) {
+  if (is.null(queue_id)) {
     driver <- hipercow_driver_select(driver, TRUE, root, call)
     r <- rrq_prepare(driver, root, ..., call = call)
   } else {

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -26,9 +26,8 @@
 ##'
 ##' @export
 hipercow_rrq_controller <- function(..., set_as_default = TRUE, driver = NULL,
-                                    root = NULL) {
+                                    queue_id = NA, root = NULL) {
   root <- hipercow_root(root)
-  queue_id <- Sys.getenv("HIPERCOW_RRQ_QUEUE_ID", NA_character_)
   call <- rlang::current_env()
   if (is.na(queue_id)) {
     driver <- hipercow_driver_select(driver, TRUE, root, call)
@@ -193,7 +192,6 @@ rrq_prepare <- function(driver, root, ..., call = NULL) {
 
 hipercow_rrq_worker <- function(queue_id, worker_id) {
   ## nocov start
-  withr::local_envvar("HIPERCOW_RRQ_QUEUE_ID" = queue_id)
   w <- rrq::rrq_worker$new(queue_id,
                            name_config = "hipercow",
                            worker_id = worker_id)

--- a/R/task-eval.R
+++ b/R/task-eval.R
@@ -72,7 +72,9 @@ task_eval <- function(id, envir = .GlobalEnv, verbose = FALSE, root = NULL) {
       hipercow_parallel_set_cores(cores, rlang::current_env())
     }
     if (isTRUE(data$parallel$use_rrq)) {
-      hipercow_rrq_controller(set_as_default = TRUE, root = root)
+      hipercow_rrq_controller(set_as_default = TRUE,
+                              queue_id = data$parallel$rrq_queue_id,
+                              root = root)
     }
 
     environment_apply(data$environment, envir, root, top, verbose)

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.34
+Version: 1.0.35
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/man/hipercow_rrq_controller.Rd
+++ b/man/hipercow_rrq_controller.Rd
@@ -4,7 +4,13 @@
 \alias{hipercow_rrq_controller}
 \title{Create an rrq controller}
 \usage{
-hipercow_rrq_controller(..., set_as_default = TRUE, driver = NULL, root = NULL)
+hipercow_rrq_controller(
+  ...,
+  set_as_default = TRUE,
+  driver = NULL,
+  queue_id = NULL,
+  root = NULL
+)
 }
 \arguments{
 \item{...}{Additional arguments passed through to
@@ -21,6 +27,10 @@ proceed.  If you have exactly one driver configured we'll submit
 your task with it.  If you have more than one driver configured,
 then we will error, though in future versions we may fall back
 on a default driver if you have one configured.}
+
+\item{queue_id}{The rrq queue id to use. You shouldn't need to pass a value
+for this: the queue id can be found from the hipercow state directory, or
+a new one is created if needed.}
 
 \item{root}{A hipercow root, or path to it. If \code{NULL} we search up
 your directory tree.}

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -308,3 +308,19 @@ test_that("can load environment from high-level function", {
   withr::with_dir(path, hipercow_parallel_load_environment("default", e))
   expect_equal(e$a, 10)
 })
+
+
+test_that("rrq queue id is exposed", {
+  skip_if_no_redis()
+  path <- withr::local_tempdir()
+  root <- init_quietly(path, driver = "example")
+  withr::defer(rrq::rrq_default_controller_clear())
+
+  r <- suppressMessages(
+    hipercow_rrq_controller(set_as_default = FALSE, root = path))
+
+  parallel <- parallel_validate(hipercow_parallel(use_rrq = TRUE),
+                                cores = 1, environment = "default",
+                                driver = "example", root = root)
+  expect_equal(parallel$rrq_queue_id, r$queue_id)
+})


### PR DESCRIPTION
The `use_rrq` option was broken: it is supposed to initialize an rrq controller in the task's process, but in order to do so it needs to find the queue ID. There was code to read a queue ID from the environment, but nowhere relevant was that environment variable set. In theory it could read it from disk, but the `HIPERCOW_NO_DRIVERS` option did not allow that.

The tests for that functionality were passing because they were manually setting `HIPERCOW_RRQ_QUEUE_ID`.

This now passes the queue ID as part of the `parallel` argument to the task, fixing the issue. Added a more comprehensive test, which actually starts the rrq tasks from a hipercow task.