### PR TITLE
Configure the rrq offload directory each time a controller is created.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     prettyunits,
     redux,
     rmarkdown,
-    rrq,
+    rrq (>= 0.7.20),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.36
+Version: 1.0.37
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -48,7 +48,7 @@ configuration_platform <- function() {
 configuration_packages <- function() {
   hipercow <- package_version_if_installed("hipercow")
 
-  nms <- c("hipercow.windows", "conan2", "logwatch")
+  nms <- c("hipercow.windows", "conan2", "logwatch", "rrq")
   pkgs <- set_names(lapply(nms, package_version_if_installed), nms)
 
   notes <- c()

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -179,7 +179,9 @@ rrq_prepare <- function(driver, root, offload_threshold_size,
   timeout_idle <- 300 # 5 minutes
   heartbeat_period <- 60 # one minute
 
-  r <- rrq::rrq_controller(queue_id, con, offload_threshold_size = offload_threshold_size, ...)
+  r <- rrq::rrq_controller(queue_id, con,
+                           offload_threshold_size = offload_threshold_size,
+                           ...)
 
   cfg <- rrq::rrq_worker_config(timeout_idle = timeout_idle,
                                 heartbeat_period = heartbeat_period,

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -20,9 +20,8 @@
 ##' @param set_as_default Set the rrq controller to be the default;
 ##'   this is usually what you want.
 ##'
-##' @param queue_id The rrq queue id to use. You shouldn't need to pass a value
-##'   for this: the queue id can be found from the hipercow state directory, or
-##'   a new one is created if needed.
+##' @param queue_id The rrq queue id to use. This parameter is used internally
+##'   by hipercow. You shouldn't ever need to pass a value for this.
 ##'
 ##' @inheritParams task_create_expr
 ##'
@@ -32,16 +31,31 @@
 hipercow_rrq_controller <- function(..., set_as_default = TRUE, driver = NULL,
                                     queue_id = NULL, root = NULL) {
   root <- hipercow_root(root)
-  offload_path <- hipercow_rrq_offload_path(root)
   call <- rlang::current_env()
+
+  offload_path <- hipercow_rrq_offload_path(root)
+  offload_threshold_size <- getOption("hipercow.rrq_offload_threshold_size",
+                                      100000) # 100k
+
   if (is.null(queue_id)) {
     driver <- hipercow_driver_select(driver, TRUE, root, call)
-    r <- rrq_prepare(driver, root, offload_path = offload_path, ...,
+    r <- rrq_prepare(driver, root,
+                     offload_path = offload_path,
+                     offload_threshold_size = offload_threshold_size,
+                     ...,
                      call = call)
   } else {
+    # TODO: this uses an offload_threshold_size that was re-evaluated locally
+    # from the options, when we would maybe want to either inherit it from the
+    # caller or read it out of the rrq worker config.
+    #
+    # Alternatively, we could use the controller that is already created by the
+    # worker code and not re-create one ourselves.
     cli::cli_alert_success("Connecting to rrq queue '{queue_id}' from task")
     r <- rrq::rrq_controller(queue_id, con = redux::hiredis(),
-                             offload_path = offload_path, ...)
+                             offload_path = offload_path,
+                             offload_threshold_size = offload_threshold_size,
+                             ...)
   }
   if (set_as_default) {
     rrq::rrq_default_controller_set(r)
@@ -140,7 +154,8 @@ hipercow_rrq_workers_submit <- function(n,
 }
 
 
-rrq_prepare <- function(driver, root, ..., call = NULL) {
+rrq_prepare <- function(driver, root, offload_threshold_size,
+                        ..., call = NULL) {
   ensure_package("rrq")
   ensure_package("redux")
   driver <- hipercow_driver_select(driver, TRUE, root, call)
@@ -164,32 +179,15 @@ rrq_prepare <- function(driver, root, ..., call = NULL) {
   timeout_idle <- 300 # 5 minutes
   heartbeat_period <- 60 # one minute
 
-  store_max_size <- getOption("hipercow.rrq_offload_threshold_size",
-                              100000) # 100k
-
-  ## We can't _generally_ use an offload like this, though we can with
-  ## the windows cluster.  This is something we'll have to think about
-  ## fairly carefully, and it might be worth holding off until we have
-  ## the linux cluster working properly, really.  We could switch this
-  ## on for the windows and example driver and nothing else perhaps,
-  ## but probably best if that is within the cluster info I think so
-  ## we can look it up.
-  withr::local_dir(root$path$root)
-  rrq::rrq_configure(queue_id, con,
-                     store_max_size = store_max_size)
-
-  r <- rrq::rrq_controller(queue_id, con, ...)
+  r <- rrq::rrq_controller(queue_id, con, offload_threshold_size = offload_threshold_size, ...)
 
   cfg <- rrq::rrq_worker_config(timeout_idle = timeout_idle,
                                 heartbeat_period = heartbeat_period,
+                                offload_threshold_size = offload_threshold_size,
                                 verbose = FALSE)
   rrq::rrq_worker_config_save("hipercow", cfg, controller = r)
-
-  ## We're going to hit the same issues here with making sure that any
-  ## remote worker can read paths as we have with submitting general
-  ## tasks; this will be easiest to think about once we have the ssh
-  ## drivers all working.
   rrq::rrq_worker_envir_set(hipercow_rrq_envir, notify = FALSE, controller = r)
+
   fs::dir_create(dirname(path_queue_id))
   cli::cli_alert_success("Created new rrq queue '{queue_id}'")
   writeLines(queue_id, path_queue_id)

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -30,8 +30,10 @@
 ##' @export
 hipercow_rrq_controller <- function(..., set_as_default = TRUE, driver = NULL,
                                     queue_id = NULL, root = NULL) {
-  root <- hipercow_root(root)
   call <- rlang::current_env()
+  check_package_version("rrq", "0.7.20", call = call)
+
+  root <- hipercow_root(root)
 
   offload_path <- hipercow_rrq_offload_path(root)
   offload_threshold_size <- getOption("hipercow.rrq_offload_threshold_size",

--- a/R/util.R
+++ b/R/util.R
@@ -498,3 +498,16 @@ find_library_with <- function(name, paths = .libPaths()) {
   }
   cli::cli_abort("Failed to find library containing {squote(name)}")
 }
+
+
+check_package_version <- function(name, minimum, call = NULL) {
+  version <- package_version_if_installed(name)
+  if (is.null(version)) {
+    cli::cli_abort(paste("Package {name} is not installed. Version {minimum}",
+                         "or greater is required."), call = call)
+  } else if (compareVersion(as.character(version), minimum) < 0) {
+    cli::cli_abort(paste("Version {version} of {name} is installed, but",
+                         "version {minimum} or greater is required."),
+                   call = call)
+  }
+}

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.36
+Version: 1.0.37
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -73,12 +73,13 @@ test_that("can report on configuration with an unconfigurable driver", {
 
 
 test_that("can report about package version problems", {
-  mock_version <- mockery::mock(1, 2, 3, 4)
+  mock_version <- mockery::mock(1, 2, 3, 4, 5)
   mockery::stub(configuration_packages, "package_version_if_installed",
                 mock_version)
   res <- configuration_packages()
   expect_equal(res$hipercow, 1)
-  expect_equal(res$others, list(hipercow.windows = 2, conan2 = 3, logwatch = 4))
+  expect_equal(res$others,
+               list(hipercow.windows = 2, conan2 = 3, logwatch = 4, rrq = 5))
   expect_equal(
     res$notes,
     c("!" = "hipercow and hipercow.windows have different versions"))
@@ -86,7 +87,7 @@ test_that("can report about package version problems", {
 
 
 test_that("can report about missing packages", {
-  mock_version <- mockery::mock(1, 2, NULL, NULL)
+  mock_version <- mockery::mock(1, 2, NULL, NULL, NULL)
   mockery::stub(configuration_packages, "package_version_if_installed",
                 mock_version)
   res <- configuration_packages()
@@ -100,7 +101,7 @@ test_that("can report about missing packages", {
 
 
 test_that("can report about everything being missing", {
-  mock_version <- mockery::mock(1, NULL, NULL, NULL)
+  mock_version <- mockery::mock(1, NULL, NULL, NULL, NULL)
   mockery::stub(configuration_packages, "package_version_if_installed",
                 mock_version)
   res <- configuration_packages()

--- a/tests/testthat/test-rrq.R
+++ b/tests/testthat/test-rrq.R
@@ -290,3 +290,30 @@ test_that("can use rrq offload", {
   expect_equal(r$store$location(hashes), "offload")
   expect_equal(r$store$get(hashes), rep(1, 1000))
 })
+
+test_that("checks rrq version", {
+  skip_if_no_redis()
+  withr::defer(rrq::rrq_default_controller_clear())
+
+  path <- withr::local_tempdir()
+  init_quietly(path, driver = "example")
+
+  mock_version <- mockery::mock(NULL,
+                                numeric_version("0.7.19"),
+                                numeric_version("0.7.20"),
+                                numeric_version("0.7.21"))
+  mockery::stub(hipercow_rrq_controller, "package_version_if_installed",
+                mock_version, depth = 2)
+
+  expect_error(hipercow_rrq_controller(root = path),
+               paste("Package rrq is not installed. Version 0.7.20 or greater",
+                     "is required."))
+
+  expect_error(hipercow_rrq_controller(root = path),
+               paste("Version 0.7.19 of rrq is installed, but version 0.7.20",
+                     "or greater is required."))
+
+  expect_no_error(suppressMessages(hipercow_rrq_controller(root = path)))
+
+  expect_no_error(suppressMessages(hipercow_rrq_controller(root = path)))
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -480,3 +480,19 @@ test_that("can find appropriate library with packages", {
   expect_equal(mockery::mock_args(mock_has_package)[[3]],
                list("a", "path/3"))
 })
+
+
+test_that("can check package version", {
+  mockery::stub(check_package_version, "package_version_if_installed", NULL)
+  expect_error(
+    check_package_version("foo", "0.2"),
+    "Package foo is not installed. Version 0.2 or greater is required.")
+
+  mockery::stub(check_package_version, "package_version_if_installed",
+                numeric_version("0.3"))
+  expect_error(
+    check_package_version("foo", "0.4"),
+    "Version 0.3 of foo is installed, but version 0.4 or greater is required.")
+  expect_no_error(check_package_version("foo", "0.3"))
+  expect_no_error(check_package_version("foo", "0.2"))
+})

--- a/vignettes/details.Rmd
+++ b/vignettes/details.Rmd
@@ -63,6 +63,19 @@ Use the development library (if it exists) for bootstrapping.  We may ask you to
 
 A number, representing seconds, for timing out when performing web requests. The default is 10s but if we have chosen this poorly you may need to increase or decrease it.
 
+## rrq options
+
+These options are only relevant when using hipercow's rrq integration.
+
+### `hipercow.rrq_offload_threshold_size`
+
+Objects passed to and from rrq tasks are usually stored in Redis. However since these are all stored in memory, larger objects are offloaded to the disk instead.
+This option controls the threshold used to decide whether or not to offload objects. Objects larger than the configured value (in bytes) are offloaded to disk.
+
+The default value is 100000, ie. 100kB.
+
+This option is used when the queue is first created. Changing it afterwards will have no effect.
+
 ## Options from other packages
 
 We make heavy use of the [`cli`](https://cli.r-lib.org/) package, see its [documentation on options](https://cli.r-lib.org/reference/cli-config.html).  Particular options that you might care about:


### PR DESCRIPTION
We previously setup the rrq offload directory once when creating the queue, storing the absolute path to it in the redis database. Using a single global value breaks down when that directory is mounted on multiple machines but at differing paths.

The most spectacular failure case happens when configuring the queue from a linux machine and using it to run on a Windows cluster. When this happens, the offload path looks something like
`/home/<user>/path/to/project/hipercow/rrq/offload`, which when used from a Windows machine obviously does not work.

This is solved by configuring each instance of an `rrq_controller` with its own path to the offload directory, relative to the hipercow root. This root is already automatically adjusted based on where we are running.