### PR TITLE
Don't use WMIC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.38
+Version: 1.0.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.38
+Version: 1.0.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/mounts.R
+++ b/drivers/windows/R/mounts.R
@@ -30,14 +30,14 @@ detect_mounts <- function() {
 
 
 detect_mounts_windows <- function() {
-  mounts <- system2("powershell", c("-c", "Get-SmbMapping|ConvertTo-CSV"), 
+  mounts <- system2("powershell", c("-c", "Get-SmbMapping|ConvertTo-CSV"),
                     stdout = TRUE)
   mounts <- read.csv(text = mounts, skip = 1, header = TRUE)
   mounts <- mounts[mounts$Status == "OK", ]
   cbind(remote = mounts$RemotePath,
         local = mounts$LocalPath)
 }
-  
+
 ## TODO: No idea what spaces in the filenames will do here.  Nothing
 ## pretty, that's for sure.
 detect_mounts_unix <- function() {

--- a/drivers/windows/tests/testthat/test-mounts.R
+++ b/drivers/windows/tests/testthat/test-mounts.R
@@ -210,10 +210,12 @@ test_that("can detect local mapping for drive", {
     "/a")
 
   expect_equal(
-    dide_locally_resolve_unc_path("//server-2.dide.ic.ac.uk/homes/b", mounts1, TRUE),
+    dide_locally_resolve_unc_path("//server-2.dide.ic.ac.uk/homes/b", mounts1,
+                                  TRUE),
     "/b")
   expect_equal(
-    dide_locally_resolve_unc_path("//server-2.dide.ic.ac.uk/homes/b", mounts2, TRUE),
+    dide_locally_resolve_unc_path("//server-2.dide.ic.ac.uk/homes/b", mounts2,
+                                  TRUE),
     "/b")
   expect_equal(
     dide_locally_resolve_unc_path("\\\\server-2.dide.ic.ac.uk\\homes\\b",


### PR DESCRIPTION
Convert from WMIC to the Powershell Get-SmbMapping - which makes things simpler.

Also in some of the mounts test, file.exits("//server-a/b") was very slow - added a skip for testing, since we only call this internally.

The failing CI is vignette timeout again and one (but not both!) of the MacOS builds fails to get R 4.4.2 