### PR TITLE
Refresh worker environment after update

### DIFF
--- a/.github/workflows/check-hipercow.yaml
+++ b/.github/workflows/check-hipercow.yaml
@@ -67,7 +67,3 @@ jobs:
           # would be better to do this conditionally (i.e., only on mac
           # runners) but the syntax for this is not obvious.
           args: 'c("--no-manual", "--no-examples")'
-
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/check-hipercow.yaml
+++ b/.github/workflows/check-hipercow.yaml
@@ -30,6 +30,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      HIPERCOW_VIGNETTE_ROOT: ${{ env.RUNNER_TEMP }}/hipercow
 
     steps:
       - uses: actions/checkout@v3
@@ -66,3 +67,7 @@ jobs:
           # would be better to do this conditionally (i.e., only on mac
           # runners) but the syntax for this is not obvious.
           args: 'c("--no-manual", "--no-examples")'
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -14,6 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      HIPERCOW_VIGNETTE_ROOT: ${{ env.RUNNER_TEMP }}/hipercow
 
     steps:
       - uses: actions/checkout@v3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.46
+Version: 1.0.47
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/environment.R
+++ b/R/environment.R
@@ -102,7 +102,8 @@ hipercow_environment_create <- function(name = "default", packages = NULL,
   if (name == "rrq" && is_rrq_enabled(root)) {
     cli::cli_alert_info("Refreshing existing rrq worker environments")
     controller <- hipercow_rrq_controller(root)
-    rrq::rrq_worker_refresh(controller)
+    ## or rrq::rrq_worker_refresh(controller) in recent rrq
+    rrq_message_send("REFRESH", controller = controller)
   }
 }
 

--- a/R/environment.R
+++ b/R/environment.R
@@ -98,6 +98,12 @@ hipercow_environment_create <- function(name = "default", packages = NULL,
     action <- if (exists) "Updated" else "Created"
     cli::cli_alert_success("{action} environment '{name}'")
   }
+
+  if (name == "rrq" && is_rrq_enabled(root)) {
+    cli::cli_alert_info("Refreshing existing rrq worker environments")
+    controller <- hipercow_rrq_controller(root)
+    rrq::rrq_worker_refresh(controller)
+  }
 }
 
 

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -224,3 +224,12 @@ hipercow_rrq_envir <- function(e) {
 hipercow_rrq_offload_path <- function(root) {
   offload_path <- file.path(root$path$rrq, "offload")
 }
+
+
+is_rrq_enabled <- function(root, call = parent.frame()) {
+  driver <- hipercow_driver_select(driver, FALSE, root, call)
+  if (!is.null(driver)) {
+    path_queue_id <- file.path(root$path$rrq, driver)
+    file.exists(path_queue_id)
+  }
+}

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -227,7 +227,8 @@ hipercow_rrq_offload_path <- function(root) {
 
 
 is_rrq_enabled <- function(root, call = parent.frame()) {
-  driver <- hipercow_driver_select(driver, FALSE, root, call)
+  driver <- hipercow_driver_select(driver = , required = FALSE,
+                                   root = root, call = call)
   if (!is.null(driver)) {
     path_queue_id <- file.path(root$path$rrq, driver)
     file.exists(path_queue_id)

--- a/R/rrq.R
+++ b/R/rrq.R
@@ -227,7 +227,7 @@ hipercow_rrq_offload_path <- function(root) {
 
 
 is_rrq_enabled <- function(root, call = parent.frame()) {
-  driver <- hipercow_driver_select(driver = , required = FALSE,
+  driver <- hipercow_driver_select(name = NULL, required = FALSE,
                                    root = root, call = call)
   if (!is.null(driver)) {
     path_queue_id <- file.path(root$path$rrq, driver)

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.46
+Version: 1.0.47
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -19,11 +19,6 @@ cleanup <- withr::with_dir(
                                     new_directory = FALSE,
                                     initialise = FALSE))
 library(hipercow)
-
-```
-
-```{r, echo = FALSE, results = "asis"}
-add_header()
 ```
 
 # Task-level parallelism

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -9,6 +9,7 @@ vignette: >
 
 ```{r setup, include = FALSE}
 source("common.R")
+options(hipercow.timeout = 120)
 vignette_root <- new_hipercow_root_path()
 fs::file_copy("simulation.R", vignette_root)
 set_vignette_root(vignette_root)

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -18,10 +18,6 @@ cleanup <- withr::with_dir(
                                     initialise = TRUE))
 ```
 
-```{r, echo = FALSE, results = "asis"}
-add_header()
-```
-
 ```{r}
 library(hipercow)
 ```


### PR DESCRIPTION
After we update the `rrq` environment we should send an environment refresh request to any active workers, otherwise people will be confused that their tasks don't use the new environment (this is noticed in the docs already in #140).

This does mean that if a user creates the rrq controller, creates the rrq env and then launches workers, the workers will load the environment twice but that's fine.