### PR TITLE
Better error messages for big objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.45
+Version: 1.0.46
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/task-create.R
+++ b/R/task-create.R
@@ -654,10 +654,12 @@ check_locals_size <- function(locals, call = NULL) {
         x = "Objects saved with a hipercow task can only be {max_size_bytes}",
         i = paste("You can increase the limit by increasing the value of",
                   "the option 'hipercow.max_size_local', even using 'Inf' to",
-                  "disable this check entirely"),
+                  "disable this check entirely (see the",
+                  "{.vignette hipercow::details} vignette)"),
         i = paste("Better again, create large objects from your 'sources'",
                   "argument to your environment, and then advertise this",
-                  "using the 'globals' argument")),
+                  "using the 'globals' argument (see the",
+                  "{.vignette hipercow::environments} vignette)")),
       call = call)
   }
 }

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.45
+Version: 1.0.46
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/vignettes/administration.Rmd
+++ b/vignettes/administration.Rmd
@@ -159,7 +159,7 @@ Users should not run this themselves into their home directories as the installa
 
 There are influential environment variables set at the driver level which prevent stan from breaking our Rtools installation.  These are
 
-```{echo = FALSE}
+```{r, echo = FALSE}
 hipercow.windows:::DEFAULT_ENVVARS[c("name", "value")]
 ```
 

--- a/vignettes/administration.Rmd
+++ b/vignettes/administration.Rmd
@@ -157,11 +157,7 @@ hipercow.windows:::cmdstan_install()
 
 Users should not run this themselves into their home directories as the installation is about 1GB
 
-There are influential environment variables set at the driver level which prevent stan from breaking our Rtools installation.  These are
-
-```{r, echo = FALSE}
-hipercow.windows:::DEFAULT_ENVVARS[c("name", "value")]
-```
+There are influential environment variables set at the driver level which prevent stan from breaking our Rtools installation (`CMDSTAN` and `CMDSTANR_USE_RTOOLS`).
 
 For details see:
 


### PR DESCRIPTION
Points at both vignettes now that cover relevant bits on this.  The fix won't work well unless the package is installed from r-universe because otherwise vignettes are not included.

I had to remove the bit from administration.Rmd - it was not rendering correctly (https://mrc-ide.github.io/hipercow/articles/administration.html#stan) and causing a warning on the vignette build; changing to make it actually call `hipercow.windows` causes a cyclic dependency.