### PR TITLE
Read cluster info from API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.52
+Version: 1.0.53
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2021
+YEAR: 2025
 COPYRIGHT HOLDER: Imperial College of Science, Technology and Medicine

--- a/R/example.R
+++ b/R/example.R
@@ -218,7 +218,7 @@ example_cluster_info <- function(config, path_root) {
                     build_queue = "fast",
                     nodes = c("node-1", "node-2", "gpu-3", "gpu-4"),
                     default_queue = "alltasks", redis_url = redis_url)
-  
+
   r_versions <- getRversion()
   list(resources = resources, r_versions = r_versions, redis_url = redis_url)
 }

--- a/R/example.R
+++ b/R/example.R
@@ -211,11 +211,14 @@ example_check_hello <- function(config, path_root) {
 
 
 example_cluster_info <- function(config, path_root) {
-  resources <- list(max_ram = 4, max_cores = 4,
-                    queues = c("alltasks", "bigmem", "fast"),
-                    nodes = c("node-1", "node-2", "gpu-3", "gpu-4"),
-                    default_queue = "alltasks")
   redis_url <- "127.0.0.1:6379"
+  resources <- list(name = "example", node_os = "example_os",
+                    max_ram = 4, max_cores = 4,
+                    queues = c("alltasks", "bigmem", "fast"),
+                    build_queue = "fast",
+                    nodes = c("node-1", "node-2", "gpu-3", "gpu-4"),
+                    default_queue = "alltasks", redis_url = redis_url)
+  
   r_versions <- getRversion()
   list(resources = resources, r_versions = r_versions, redis_url = redis_url)
 }

--- a/R/provision.R
+++ b/R/provision.R
@@ -138,7 +138,6 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  
   dat$driver$provision_run(args, check_running_tasks, dat$config,
                            root$path$root)
   invisible()

--- a/R/provision.R
+++ b/R/provision.R
@@ -138,6 +138,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
+  
   dat$driver$provision_run(args, check_running_tasks, dat$config,
                            root$path$root)
   invisible()

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.52
+Version: 1.0.53
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -14,8 +14,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
-URL: https://github.com/mrc-ide/hipercow.windows
-BugReports: https://github.com/mrc-ide/hipercow.windows/issues
+URL: https://github.com/mrc-ide/hipercow
+BugReports: https://github.com/mrc-ide/hipercow/issues
 Imports:
     cli,
     conan2  (>= 1.9.95),

--- a/drivers/windows/LICENSE
+++ b/drivers/windows/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2021
+YEAR: 2025
 COPYRIGHT HOLDER: Imperial College of Science, Technology and Medicine

--- a/drivers/windows/R/cluster.R
+++ b/drivers/windows/R/cluster.R
@@ -36,7 +36,7 @@ r_versions_fetch <- function() {
 
 cluster_resources <- function(cluster, driver) {
   if (is.null(cache$cluster_resources)) {
-    cache$cluster_resources <- 
+    cache$cluster_resources <-
       cluster_resources_fetch(cluster, driver)
   }
   cache$cluster_resources

--- a/drivers/windows/R/cluster.R
+++ b/drivers/windows/R/cluster.R
@@ -29,6 +29,22 @@ r_versions <- function() {
 
 
 r_versions_fetch <- function() {
-  credentials <- list(username = "public", username = "public")
+  credentials <- list(username = "public")
   web_client$new(credentials, login = FALSE)$r_versions()
+}
+
+
+cluster_resources <- function(cluster, driver) {
+  if (is.null(cache$cluster_resources)) {
+    cache$cluster_resources <- 
+      cluster_resources_fetch(cluster, driver)
+  }
+  cache$cluster_resources
+}
+
+
+cluster_resources_fetch <- function(cluster, driver) {
+  credentials <- list(username = "public")
+  web_client$new(credentials, login = FALSE)$cluster_resources(
+    "wpia-hn", "hipercow.windows")
 }

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -90,7 +90,7 @@ windows_check_hello <- function(config, path_root) {
     cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
-  resources$queue <- config$resources$build_queue
+  resources$queue <- cluster_resources()$build_queue
   resources
 }
 

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -90,7 +90,7 @@ windows_check_hello <- function(config, path_root) {
     cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
-  resources$queue <- "BuildQueue"
+  resources$queue <- config$resources$build_queue
   resources
 }
 

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -30,7 +30,7 @@ windows_provision_run <- function(args, check_running_tasks, config,
 
   res <- hipercow::hipercow_resources()
   res <- hipercow::hipercow_resources_validate(res, root = path_root)
-  res$queue <- "BuildQueue"
+  res$queue <- config$resources$build_queue
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
 
   path_dide_id <- file.path(dirname(path_batch), DIDE_ID)

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -30,7 +30,7 @@ windows_provision_run <- function(args, check_running_tasks, config,
 
   res <- hipercow::hipercow_resources()
   res <- hipercow::hipercow_resources_validate(res, root = path_root)
-  res$queue <- config$resources$build_queue
+  res$queue <- cluster_resources()$build_queue
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
 
   path_dide_id <- file.path(dirname(path_batch), DIDE_ID)

--- a/drivers/windows/R/resource.R
+++ b/drivers/windows/R/resource.R
@@ -10,15 +10,9 @@ windows_cluster_info <- function(config, path_root) {
 
 
 cluster_info_wpia_hn <- function() {
-  resources <- list(
-    max_cores = 32,
-    max_ram = 512,
-    queues = c("AllNodes", "Testing"),
-    default_queue = "AllNodes",
-    nodes = sprintf("wpia-%003d", (1:89)[-c(41, 42, 49, 50)])
-  )
-  redis_url <- "wpia-hn.hpc.dide.ic.ac.uk"
+  browser()
+  resources <- cluster_resources("wpia-hn", "hipercow.windows")
   list(resources = resources,
        r_versions = r_versions(),
-       redis_url = redis_url)
+       redis_url = resources$redis_url)
 }

--- a/drivers/windows/R/resource.R
+++ b/drivers/windows/R/resource.R
@@ -10,7 +10,6 @@ windows_cluster_info <- function(config, path_root) {
 
 
 cluster_info_wpia_hn <- function() {
-  browser()
   resources <- cluster_resources("wpia-hn", "hipercow.windows")
   list(resources = resources,
        r_versions = r_versions(),

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -108,7 +108,7 @@ web_client <- R6::R6Class(
       r <- private$client$GET("/api/v1/cluster_software/", public = TRUE)
       client_parse_r_versions(httr_text(r))
     },
-    
+
     cluster_resources = function(cluster, driver) {
       r <- private$client$GET(
         sprintf("/api/v1/cluster_info/%s/%s", cluster, driver),

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -108,6 +108,13 @@ web_client <- R6::R6Class(
       r <- private$client$GET("/api/v1/cluster_software/", public = TRUE)
       client_parse_r_versions(httr_text(r))
     },
+    
+    cluster_resources = function(cluster, driver) {
+      r <- private$client$GET(
+        sprintf("/api/v1/cluster_info/%s/%s", cluster, driver),
+        public = TRUE)
+      client_parse_cluster_info(httr_text(r))
+    },
 
     api_client = function() {
       private$client
@@ -381,6 +388,11 @@ client_parse_r_versions <- function(txt) {
   dat <- from_json(txt)
   dat_r <- dat$software[vcapply(dat$software, "[[", "name") == "R"]
   numeric_version(vcapply(dat_r, "[[", "version"))
+}
+
+
+client_parse_cluster_info <- function(txt) {
+  from_json(txt)
 }
 
 

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -113,7 +113,7 @@ web_client <- R6::R6Class(
       r <- private$client$GET(
         sprintf("/api/v1/cluster_info/%s/%s", cluster, driver),
         public = TRUE)
-      client_parse_cluster_info(httr_text(r))
+      client_parse_cluster_resources(httr_text(r))
     },
 
     api_client = function() {
@@ -391,7 +391,7 @@ client_parse_r_versions <- function(txt) {
 }
 
 
-client_parse_cluster_info <- function(txt) {
+client_parse_cluster_resources <- function(txt) {
   from_json(txt)
 }
 

--- a/drivers/windows/tests/testthat/test-resource.R
+++ b/drivers/windows/tests/testthat/test-resource.R
@@ -4,7 +4,9 @@ test_that("Cluster info returns something for wpia-hn", {
   expect_setequal(names(res), c("resources", "r_versions", "redis_url"))
   expect_setequal(
     names(res$resources),
-    c("max_cores", "max_ram", "queues", "default_queue", "nodes"))
+    c("name", "node_os",
+      "max_cores", "max_ram", "queues", "default_queue", "nodes",
+      "build_queue", "redis_url"))
   expect_s3_class(res$r_versions, "numeric_version")
   expect_equal(res$r_versions, r_versions())
   expect_equal(res$redis_url, "wpia-hn.hpc.dide.ic.ac.uk")

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -117,7 +117,7 @@ test_that("example cluster info is meagre", {
   expect_setequal(names(info), c("resources", "r_versions", "redis_url"))
   expect_setequal(
     names(info$resources),
-    c("name", "node_os", "max_cores", "max_ram", "queues", "default_queue", 
+    c("name", "node_os", "max_cores", "max_ram", "queues", "default_queue",
       "build_queue", "redis_url", "nodes"))
   expect_s3_class(info$r_versions, "numeric_version")
   expect_equal(info$resources$max_ram, 4)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -117,7 +117,8 @@ test_that("example cluster info is meagre", {
   expect_setequal(names(info), c("resources", "r_versions", "redis_url"))
   expect_setequal(
     names(info$resources),
-    c("max_cores", "max_ram", "queues", "default_queue", "nodes"))
+    c("name", "node_os", "max_cores", "max_ram", "queues", "default_queue", 
+      "build_queue", "redis_url", "nodes"))
   expect_s3_class(info$r_versions, "numeric_version")
   expect_equal(info$resources$max_ram, 4)
   expect_equal(info$resources$max_cores, 4)


### PR DESCRIPTION
This replaces the hard-coded properties of the windows cluster with a read to the API at 

https://mrcdata.dide.ic.ac.uk/hpc/api/v1/cluster_info/wpia-hn/hipercow.windows/

and the next PR will use 

https://mrcdata.dide.ic.ac.uk/hpc/api/v1/cluster_info/wpia-hn/hipercow.linux/

This should help re-use parts of hipercow.windows - and just seems a better thing to do anyway, so that changes in queue/node/template can be done with the API rather than the code