### PR TITLE
mrc-6185 - Linux support on Win driver part 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.0.53
+Version: 1.0.54
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -7,8 +7,8 @@
 ##' @param driver The driver to use, which determines the cluster to
 ##'   fetch information from (depending on your configuration).  If no
 ##'   driver is configured, an error will be thrown.
-##'   
-##' @param platform The operating system you are intending to run 
+##'
+##' @param platform The operating system you are intending to run
 ##'   jobs on. By default this is `windows`, which we have traditionally
 ##'   supported, but the MS-HPC cluster also can support `linux` nodes.
 ##'   Where hipercow cluster drivers support multiple operating systems,

--- a/R/cluster.R
+++ b/R/cluster.R
@@ -7,6 +7,12 @@
 ##' @param driver The driver to use, which determines the cluster to
 ##'   fetch information from (depending on your configuration).  If no
 ##'   driver is configured, an error will be thrown.
+##'   
+##' @param platform The operating system you are intending to run 
+##'   jobs on. By default this is `windows`, which we have traditionally
+##'   supported, but the MS-HPC cluster also can support `linux` nodes.
+##'   Where hipercow cluster drivers support multiple operating systems,
+##'   you can specify which platform you would like information on here.
 ##'
 ##' @inheritParams hipercow_configure
 ##'
@@ -31,14 +37,15 @@
 ##' cleanup <- hipercow_example_helper()
 ##' hipercow_cluster_info()
 ##' cleanup()
-hipercow_cluster_info <- function(driver = NULL, root = NULL) {
+hipercow_cluster_info <- function(driver = NULL, root = NULL,
+                                  platform = "windows") {
   root <- hipercow_root(root)
   driver <- hipercow_driver_select(driver, TRUE, root, call)
-  cluster_info(driver, root)
+  cluster_info(driver, root, platform)
 }
 
 
-cluster_info <- function(driver, root) {
+cluster_info <- function(driver, root, platform = "windows") {
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$cluster_info(dat$config, root$path$root)
+  dat$driver$cluster_info(dat$config, root$path$root, platform)
 }

--- a/R/example.R
+++ b/R/example.R
@@ -210,7 +210,7 @@ example_check_hello <- function(config, path_root) {
 }
 
 
-example_cluster_info <- function(config, path_root) {
+example_cluster_info <- function(config, path_root, platform = "example") {
   redis_url <- "127.0.0.1:6379"
   resources <- list(name = "example", node_os = "example_os",
                     max_ram = 4, max_cores = 4,

--- a/R/example.R
+++ b/R/example.R
@@ -158,7 +158,7 @@ example_cancel <- function(id, config, path_root) {
 
 
 example_provision_run <- function(args, check_running_tasks, config,
-                                  path_root) {
+                                  path_root, platform) {
   path_bootstrap <- find_library_with("pkgdepends")
   conan_config <- rlang::inject(conan2::conan_configure(
     !!!args,
@@ -170,7 +170,7 @@ example_provision_run <- function(args, check_running_tasks, config,
 }
 
 
-example_provision_list <- function(args, config, path_root) {
+example_provision_list <- function(args, config, path_root, platform) {
   if (is.null(args)) {
     hash <- NULL
   } else {
@@ -186,7 +186,8 @@ example_provision_list <- function(args, config, path_root) {
 }
 
 
-example_provision_compare <- function(curr, prev, config, path_root) {
+example_provision_compare <- function(curr, prev, config, path_root, 
+                                      platform) {
   path_lib <- file.path(path_root, "hipercow", "lib")
   conan2::conan_compare(path_lib, curr, prev)
 }
@@ -206,7 +207,7 @@ example_keypair <- function(config, path_root) {
 }
 
 
-example_check_hello <- function(config, path_root) {
+example_check_hello <- function(config, path_root, platform) {
 }
 
 

--- a/R/example.R
+++ b/R/example.R
@@ -186,7 +186,7 @@ example_provision_list <- function(args, config, path_root, platform) {
 }
 
 
-example_provision_compare <- function(curr, prev, config, path_root, 
+example_provision_compare <- function(curr, prev, config, path_root,
                                       platform) {
   path_lib <- file.path(path_root, "hipercow", "lib")
   conan2::conan_compare(path_lib, curr, prev)

--- a/R/hello.R
+++ b/R/hello.R
@@ -8,12 +8,12 @@
 ##'   be omitted where you have exactly one driver, but we error if
 ##'   not given when you have more than one driver, or if you have not
 ##'   configured any drivers.
-##'   
+##'
 ##' @param platform If the driver can target nodes running different
 ##'   operating systems, then we can run hello world targeting that
 ##'   platform. The default is `windows`, and `linux` can also be used
 ##'   to test linux nodes connected to our MS-HPC cluster with the
-##'   hipercow.windows driver. 
+##'   hipercow.windows driver.
 ##'
 ##' @inheritParams task_log_watch
 ##'

--- a/R/hello.R
+++ b/R/hello.R
@@ -8,6 +8,12 @@
 ##'   be omitted where you have exactly one driver, but we error if
 ##'   not given when you have more than one driver, or if you have not
 ##'   configured any drivers.
+##'   
+##' @param platform If the driver can target nodes running different
+##'   operating systems, then we can run hello world targeting that
+##'   platform. The default is `windows`, and `linux` can also be used
+##'   to test linux nodes connected to our MS-HPC cluster with the
+##'   hipercow.windows driver. 
 ##'
 ##' @inheritParams task_log_watch
 ##'
@@ -20,12 +26,13 @@
 ##' hipercow_hello()
 ##'
 ##' cleanup()
-hipercow_hello <- function(progress = NULL, timeout = NULL, driver = NULL) {
+hipercow_hello <- function(progress = NULL, timeout = NULL, driver = NULL,
+                           platform = "windows") {
   root <- hipercow_root(NULL)
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
 
   dat <- hipercow_driver_prepare(driver, root, environment())
-  resources <- dat$driver$check_hello(dat$config, root$path$root)
+  resources <- dat$driver$check_hello(dat$config, root$path$root, platform)
 
   moo <- read_lines(hipercow_file("comms/moo"))
   id <- task_create_expr({

--- a/R/provision.R
+++ b/R/provision.R
@@ -110,9 +110,9 @@
 ##'   may get a corrupted library if a package is upgraded while it is
 ##'   loaded.  You can disable this check by passing `FALSE`.  Not all
 ##'   drivers respond to this argument, but the windows driver does.
-##'   
+##'
 ##' @param platform The operating system that this provision should
-##'   target. The default is `windows` as so far this has been the 
+##'   target. The default is `windows` as so far this has been the
 ##'   platform we have supported in DIDE. But as of Hipercow 1.0.54
 ##'   or later, the windows driver now also supports linux nodes
 ##'   connected to the MS-HPC headnode. To target jobs onto the linux
@@ -148,7 +148,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_run(args, check_running_tasks, dat$config, 
+  dat$driver$provision_run(args, check_running_tasks, dat$config,
                            root$path$root, platform)
   invisible()
 }
@@ -194,7 +194,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 ##' hipercow_provision_check()
 ##'
 ##' cleanup()
-hipercow_provision_list <- function(driver = NULL, root = NULL, 
+hipercow_provision_list <- function(driver = NULL, root = NULL,
                                     platform = "windows") {
   root <- hipercow_root(root)
   ensure_package("conan2", rlang::current_env())
@@ -257,6 +257,6 @@ hipercow_provision_compare <- function(curr = 0, prev = -1, driver = NULL,
   ensure_package("conan2", rlang::current_env())
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_compare(curr, prev, dat$config, root$path$root, 
+  dat$driver$provision_compare(curr, prev, dat$config, root$path$root,
                                platform)
 }

--- a/R/provision.R
+++ b/R/provision.R
@@ -110,6 +110,15 @@
 ##'   may get a corrupted library if a package is upgraded while it is
 ##'   loaded.  You can disable this check by passing `FALSE`.  Not all
 ##'   drivers respond to this argument, but the windows driver does.
+##'   
+##' @param platform The operating system that this provision should
+##'   target. The default is `windows` as so far this has been the 
+##'   platform we have supported in DIDE. But as of Hipercow 1.0.54
+##'   or later, the windows driver now also supports linux nodes
+##'   connected to the MS-HPC headnode. To target jobs onto the linux
+##'   nodes, you will need to provision a linux package repo, with
+##'   `platform = 'linux'`. This is new and experimental, and the
+##'   interface may change.
 ##'
 ##' @inheritParams task_submit
 ##'
@@ -126,7 +135,8 @@
 hipercow_provision <- function(method = NULL, ..., driver = NULL,
                                environment = "default",
                                check_running_tasks = TRUE,
-                               root = NULL) {
+                               root = NULL,
+                               platform = "windows") {
   ## TODO: here, if *no* driver is found that could be that we are
   ## running on the headnode, either by job submission or directly,
   ## and we'll need to handle that too.
@@ -138,8 +148,8 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_run(args, check_running_tasks, dat$config,
-                           root$path$root)
+  dat$driver$provision_run(args, check_running_tasks, dat$config, 
+                           root$path$root, platform = "windows")
   invisible()
 }
 

--- a/R/provision.R
+++ b/R/provision.R
@@ -149,7 +149,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
   dat$driver$provision_run(args, check_running_tasks, dat$config, 
-                           root$path$root, platform = "windows")
+                           root$path$root, platform)
   invisible()
 }
 
@@ -194,12 +194,13 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 ##' hipercow_provision_check()
 ##'
 ##' cleanup()
-hipercow_provision_list <- function(driver = NULL, root = NULL) {
+hipercow_provision_list <- function(driver = NULL, root = NULL, 
+                                    platform = "windows") {
   root <- hipercow_root(root)
   ensure_package("conan2", rlang::current_env())
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_list(NULL, dat$config, root$path$root)
+  dat$driver$provision_list(NULL, dat$config, root$path$root, platform)
 }
 
 
@@ -207,14 +208,14 @@ hipercow_provision_list <- function(driver = NULL, root = NULL) {
 ##' @export
 hipercow_provision_check <- function(method = NULL, ..., driver = NULL,
                                      environment = "default",
-                                     root = NULL) {
+                                     root = NULL, platform = "windows") {
   root <- hipercow_root(root)
   ensure_package("conan2", rlang::current_env())
   env <- environment_load(environment, root, rlang::current_env())
   args <- list(method = method, environment = env, ...)
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_list(args, dat$config, root$path$root)
+  dat$driver$provision_list(args, dat$config, root$path$root, platform)
 }
 
 
@@ -251,10 +252,11 @@ hipercow_provision_check <- function(method = NULL, ..., driver = NULL,
 ##'
 ##' cleanup()
 hipercow_provision_compare <- function(curr = 0, prev = -1, driver = NULL,
-                                       root = NULL) {
+                                       root = NULL, platform = "windows") {
   root <- hipercow_root(root)
   ensure_package("conan2", rlang::current_env())
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
-  dat$driver$provision_compare(curr, prev, dat$config, root$path$root)
+  dat$driver$provision_compare(curr, prev, dat$config, root$path$root, 
+                               platform)
 }

--- a/R/resource.R
+++ b/R/resource.R
@@ -275,14 +275,15 @@ validate_queue <- function(queue, call = call) {
 ##'   error = identity)
 ##'
 ##' cleanup()
-hipercow_resources_validate <- function(resources, driver = NULL, root = NULL) {
+hipercow_resources_validate <- function(resources, platform = "windows",
+                                        driver = NULL, root = NULL) {
   root <- hipercow_root(root)
   driver <- hipercow_driver_select(driver, FALSE, root, rlang::current_env())
-  resources_validate(resources, driver, root)
+  resources_validate(resources, driver, root, platform)
 }
 
 
-resources_validate <- function(resources, driver, root) {
+resources_validate <- function(resources, driver, root, platform = "windows") {
   already_valid <-
     (identical(attr(resources, "validated", exact = TRUE), driver)) &&
     !is.null(driver) # identical would be true when driver not given otherwise
@@ -304,7 +305,7 @@ resources_validate <- function(resources, driver, root) {
     }
     return(resources)
   }
-  cluster_resources <- cluster_info(driver, root)$resources
+  cluster_resources <- cluster_info(driver, root, platform)$resources
 
   if (is.null(resources$queue)) {
     resources$queue <- cluster_resources$default_queue

--- a/R/resource.R
+++ b/R/resource.R
@@ -275,8 +275,8 @@ validate_queue <- function(queue, call = call) {
 ##'   error = identity)
 ##'
 ##' cleanup()
-hipercow_resources_validate <- function(resources, platform = "windows",
-                                        driver = NULL, root = NULL) {
+hipercow_resources_validate <- function(resources, driver = NULL, root = NULL,
+                                        platform = "windows") {
   root <- hipercow_root(root)
   driver <- hipercow_driver_select(driver, FALSE, root, rlang::current_env())
   resources_validate(resources, driver, root, platform)

--- a/R/resource.R
+++ b/R/resource.R
@@ -260,8 +260,15 @@ validate_queue <- function(queue, call = call) {
 ##'
 ##' @param resources A [hipercow_resources] list returned by
 ##'   [hipercow_resources], or `NULL`
+##'   
+##' @param platform The MS-HPC cluster targeted by the hipercow.windows
+##'   driver, supports both windows and linux nodes, which may have
+##'   different capabilities and software versions. Specify a platform
+##'   here (`windows` is the default, or `linux`) to validate resources
+##'   against the node capabilities available for that platform.
 ##'
-##' @return TRUE if the resources are compatible with this driver.
+##' @return TRUE if the resources are compatible with this driver
+##'   and platform.
 ##'
 ##' @inheritParams task_submit
 ##' @export

--- a/R/resource.R
+++ b/R/resource.R
@@ -260,7 +260,7 @@ validate_queue <- function(queue, call = call) {
 ##'
 ##' @param resources A [hipercow_resources] list returned by
 ##'   [hipercow_resources], or `NULL`
-##'   
+##'
 ##' @param platform The MS-HPC cluster targeted by the hipercow.windows
 ##'   driver, supports both windows and linux nodes, which may have
 ##'   different capabilities and software versions. Specify a platform

--- a/drivers/windows/DESCRIPTION
+++ b/drivers/windows/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.windows
 Title: DIDE HPC Support for Windows
-Version: 1.0.53
+Version: 1.0.54
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/windows/R/batch.R
+++ b/drivers/windows/R/batch.R
@@ -22,7 +22,8 @@ read_template <- function(name) {
   read_lines(hipercow_windows_file(sprintf("templates/%s", name)))
 }
 
-template_data_task_run <- function(task_id, config, path_root) {
+template_data_task_run <- function(task_id, config, path_root,
+                                   platform = "windows") {
   data <- template_data_common(config, path_root)
   data$task_id <- task_id
   data$task_id_1 <- substr(task_id, 1, 2)
@@ -31,8 +32,9 @@ template_data_task_run <- function(task_id, config, path_root) {
   ## Semicolon delimited list on windows; see "Managing libraries" in
   ## https://cran.r-project.org/doc/manuals/r-release/R-admin.html
   data$hipercow_library <- paste(
-    remote_path(file.path(path_root, config$path_lib), config$shares),
-    path_bootstrap(config),
+    remote_path(file.path(path_root, config$path_lib[[platform]]),
+                config$shares),
+    path_bootstrap(config, platform),
     sep = ";")
 
   data$renviron_path <-
@@ -74,8 +76,10 @@ template_data_common <- function(config, path_root) {
     cluster_name = config$cluster)
 }
 
-path_bootstrap <- function(config) {
+path_bootstrap <- function(config, platform = "windows") {
   use_development <- getOption("hipercow.development", FALSE)
-  base <- if (use_development) "bootstrap-dev" else "bootstrap"
-  sprintf("I:/%s/%s", base, version_string(config$r_version, "."))
+  base <- sprintf("bootstrap%s%s",
+                  if (platform == "linux") "-linux" else "",
+                  if (use_development) "-dev" else "")
+  sprintf("I:/%s/%s", base, version_string(config$r_version[[platform]], "."))
 }

--- a/drivers/windows/R/bootstrap.R
+++ b/drivers/windows/R/bootstrap.R
@@ -1,31 +1,46 @@
-bootstrap_update <- function(development = NULL, root = NULL) {
+bootstrap_update <- function(development = NULL, root = NULL,
+                             platform = "windows") {
   path_script <- "hipercow/bootstrap-windows.R"
   path_root <- hipercow:::hipercow_root(root)$path$root
   path_script_abs <- file.path(path_root, path_script)
   dir.create(dirname(path_script_abs), FALSE, TRUE)
   bootstrap <- read_template("bootstrap.R")
+
+  bootstrap_path <- "bootstrap"
+  if (platform == "linux") {
+    bootstrap_path <- "bootstrap-linux"
+  }
   if (is.null(development)) {
-    data <- list(bootstrap_path = "bootstrap",
+    data <- list(bootstrap_path = bootstrap_path,
                  development_ref = "NULL")
   } else {
-    data <- list(bootstrap_path = "bootstrap-dev",
+    data <- list(bootstrap_path = paste0(bootstrap_path, "-dev"),
                  development_ref = dquote(development))
   }
   writelines_if_different(glue_whisker(bootstrap, data),
                           path_script_abs)
-  hipercow::hipercow_provision("script", script = path_script, root = root)
+  hipercow::hipercow_provision("script", script = path_script, root = root,
+                               platform = platform)
 }
 
 
 bootstrap_update_all <- function(development = NULL, root = NULL,
-                                 versions = r_versions()) {
-  versions <- recent_versions(as.numeric_version(versions))
-  for (i in seq_along(versions)) {
-    version <- versions[[i]]
-    cli::cli_alert_info("Setting up bootstrap for R {version}")
-    hipercow::hipercow_init(root %||% ".", driver = "windows",
-                            r_version = version)
-    bootstrap_update(development = development, root = root)
+                                 versions = NULL,
+                                 platforms = "windows") {
+  for (platform in platforms) {
+    platform_versions <- r_versions(platform)
+    if (!is.null(versions)) {
+      platform_versions <- platform_versions[platform_versions %in% versions]
+    }
+    platform_versions <- recent_versions(as.numeric_version(platform_versions))
+    for (i in seq_along(platform_versions)) {
+      version <- platform_versions[[i]]
+      cli::cli_alert_info("Setting up bootstrap for R {version}")
+      hipercow::hipercow_init(root %||% ".", driver = "windows",
+                              r_version = version)
+      bootstrap_update(development = development, root = root,
+                       platform = platform)
+    }
   }
 }
 

--- a/drivers/windows/R/cluster.R
+++ b/drivers/windows/R/cluster.R
@@ -20,31 +20,36 @@ valid_clusters <- function() {
 }
 
 
-r_versions <- function() {
-  if (is.null(cache$r_versions)) {
-    cache$r_versions <- r_versions_fetch()
+r_versions <- function(platform) {
+  if (!is.list(cache$r_versions)) {
+    cache$r_versions <- list()
   }
-  cache$r_versions
-}
-
-
-r_versions_fetch <- function() {
-  credentials <- list(username = "public")
-  web_client$new(credentials, login = FALSE)$r_versions()
-}
-
-
-cluster_resources <- function(cluster, driver) {
-  if (is.null(cache$cluster_resources)) {
-    cache$cluster_resources <-
-      cluster_resources_fetch(cluster, driver)
+  if (is.null(cache$r_versions[[platform]])) {
+    cache$r_versions[[platform]] <- r_versions_fetch(platform)
   }
-  cache$cluster_resources
+  cache$r_versions[[platform]]
 }
 
 
-cluster_resources_fetch <- function(cluster, driver) {
+r_versions_fetch <- function(platform) {
   credentials <- list(username = "public")
-  web_client$new(credentials, login = FALSE)$cluster_resources(
-    "wpia-hn", "hipercow.windows")
+  web_client$new(credentials, platform, login = FALSE)$r_versions()
+}
+
+
+cluster_resources <- function(platform) {
+  if (!is.list(cache$cluster_resources)) {
+    cache$cluster_resources <- list()
+  }
+  if (is.null(cache$cluster_resources[[platform]])) {
+    cache$cluster_resources[[platform]] <-
+      cluster_resources_fetch(platform)
+  }
+  cache$cluster_resources[[platform]]
+}
+
+
+cluster_resources_fetch <- function(platform) {
+  credentials <- list(username = "public")
+  web_client$new(credentials, platform, login = FALSE)$cluster_resources()
 }

--- a/drivers/windows/R/cluster.R
+++ b/drivers/windows/R/cluster.R
@@ -20,9 +20,9 @@ valid_clusters <- function() {
 }
 
 
-r_versions <- function(platform) {
+r_versions <- function(platform = "windows") {
   if (!is.list(cache$r_versions)) {
-    cache$r_versions <- list()
+    assign("r_versions", list(), envir = cache)
   }
   if (is.null(cache$r_versions[[platform]])) {
     cache$r_versions[[platform]] <- r_versions_fetch(platform)
@@ -31,15 +31,15 @@ r_versions <- function(platform) {
 }
 
 
-r_versions_fetch <- function(platform) {
+r_versions_fetch <- function(platform = "windows") {
   credentials <- list(username = "public")
   web_client$new(credentials, platform, login = FALSE)$r_versions()
 }
 
 
-cluster_resources <- function(platform) {
+cluster_resources <- function(platform = "windows") {
   if (!is.list(cache$cluster_resources)) {
-    cache$cluster_resources <- list()
+    assign("cluster_resources", list(), envir = cache)
   }
   if (is.null(cache$cluster_resources[[platform]])) {
     cache$cluster_resources[[platform]] <-
@@ -49,7 +49,7 @@ cluster_resources <- function(platform) {
 }
 
 
-cluster_resources_fetch <- function(platform) {
+cluster_resources_fetch <- function(platform = "windows") {
   credentials <- list(username = "public")
   web_client$new(credentials, platform, login = FALSE)$cluster_resources()
 }

--- a/drivers/windows/R/config.R
+++ b/drivers/windows/R/config.R
@@ -1,5 +1,4 @@
 windows_configure <- function(shares = NULL, r_version = NULL) {
-  browser()
   path <- getwd()
   r_version <- select_r_version(r_version)
   r_version_str <- version_string(r_version, ".")
@@ -14,7 +13,10 @@ windows_configure <- function(shares = NULL, r_version = NULL) {
 
 
 select_r_version <- function(r_version, ours = getRversion(),
-                             valid = r_versions()) {
+                             valid = unique(c(
+                               r_versions("windows"),
+                               r_versions("linux")))) {
+
   select_by_match <- is.null(r_version)
   if (select_by_match) {
     if (ours %in% valid) {

--- a/drivers/windows/R/config.R
+++ b/drivers/windows/R/config.R
@@ -1,4 +1,5 @@
 windows_configure <- function(shares = NULL, r_version = NULL) {
+  browser()
   path <- getwd()
   r_version <- select_r_version(r_version)
   r_version_str <- version_string(r_version, ".")

--- a/drivers/windows/R/driver.R
+++ b/drivers/windows/R/driver.R
@@ -85,12 +85,12 @@ windows_cancel <- function(id, config, path_root) {
 }
 
 
-windows_check_hello <- function(config, path_root) {
+windows_check_hello <- function(config, path_root, platform = "windows") {
   if (!windows_check(path_root)) {
     cli::cli_abort("Failed checks for using windows cluster; please see above")
   }
   resources <- hipercow::hipercow_resources_validate(NULL, "windows", path_root)
-  resources$queue <- cluster_resources()$build_queue
+  resources$queue <- cluster_resources(platform)$build_queue
   resources
 }
 

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -63,7 +63,8 @@ windows_provision_run <- function(args, check_running_tasks,
 }
 
 
-windows_provision_list <- function(args, config, path_root) {
+windows_provision_list <- function(args, config, path_root,
+                                   platform = "windows") {
   if (is.null(args)) {
     hash <- NULL
   } else {
@@ -78,7 +79,8 @@ windows_provision_list <- function(args, config, path_root) {
 }
 
 
-windows_provision_compare <- function(curr, prev, config, path_root) {
+windows_provision_compare <- function(curr, prev, config, path_root,
+                                      platform = "windows") {
   path_lib <- file.path(path_root, config$path_lib)
   conan2::conan_compare(path_lib, curr, prev)
 }

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -1,5 +1,5 @@
 ## windows-specific provisioning code, called from hipercow
-windows_provision_run <- function(args, check_running_tasks, 
+windows_provision_run <- function(args, check_running_tasks,
                                   config, path_root, platform = "windows") {
   assert_scalar(platform)
   if (!platform %in% c("windows", "linux")) {
@@ -9,7 +9,7 @@ windows_provision_run <- function(args, check_running_tasks,
   poll <- args$poll %||% 1
   args$show_log <- NULL
   args$poll <- NULL
-  
+
   client <- get_web_client(platform)
   check_old_versions(r_versions(platform), config$r_version, getRversion())
   if (check_running_tasks) {

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -11,7 +11,8 @@ windows_provision_run <- function(args, check_running_tasks,
   args$poll <- NULL
 
   client <- get_web_client(platform)
-  check_old_versions(r_versions(platform), config$r_version, getRversion())
+  check_old_versions(r_versions(platform), config$r_version[[platform]],
+                     getRversion())
   if (check_running_tasks) {
     check_running_before_install(client, path_root = path_root)
   }
@@ -19,7 +20,7 @@ windows_provision_run <- function(args, check_running_tasks,
   conan_config <- rlang::inject(conan2::conan_configure(
     !!!args,
     path = path_root,
-    path_lib = config$path_lib,
+    path_lib = config$path_lib[[platform]],
     path_bootstrap = path_bootstrap(config)))
 
   id <- ids::random_id()
@@ -71,17 +72,17 @@ windows_provision_list <- function(args, config, path_root,
     hash <- conan_config <- rlang::inject(conan2::conan_configure(
               !!!args,
               path = path_root,
-              path_lib = config$path_lib,
+              path_lib = config$path_lib[[platform]],
               path_bootstrap = path_bootstrap(config)))$hash
   }
-  path_lib <- file.path(path_root, config$path_lib)
+  path_lib <- file.path(path_root, config$path_lib[[platform]])
   conan2::conan_list(path_lib, hash)
 }
 
 
 windows_provision_compare <- function(curr, prev, config, path_root,
                                       platform = "windows") {
-  path_lib <- file.path(path_root, config$path_lib)
+  path_lib <- file.path(path_root, config$path_lib[[platform]])
   conan2::conan_compare(path_lib, curr, prev)
 }
 

--- a/drivers/windows/R/provision.R
+++ b/drivers/windows/R/provision.R
@@ -33,7 +33,7 @@ windows_provision_run <- function(args, check_running_tasks,
     file.path(path_batch_dat$path_remote, path_batch_dat$rel))
 
   res <- hipercow::hipercow_resources()
-  res <- hipercow::hipercow_resources_validate(res, platform, root = path_root)
+  res <- hipercow::hipercow_resources_validate(res, root = path_root, platform)
   res$queue <- cluster_resources(platform)$build_queue
   dide_id <- client$submit(path_batch_unc, sprintf("conan:%s", id), res)
 

--- a/drivers/windows/R/resource.R
+++ b/drivers/windows/R/resource.R
@@ -1,6 +1,6 @@
 ## windows-specific cluster functions, called from hipercow.
 
-windows_cluster_info <- function(config, platform, path_root) {
+windows_cluster_info <- function(config, path_root, platform = "windows") {
   switch(config$cluster,
          "wpia-hn" = cluster_info_wpia_hn(platform),
          cli::cli_abort(c(
@@ -9,7 +9,7 @@ windows_cluster_info <- function(config, platform, path_root) {
 }
 
 
-cluster_info_wpia_hn <- function(platform) {
+cluster_info_wpia_hn <- function(platform = "windows") {
   resources <- cluster_resources(platform)
   list(resources = resources,
        r_versions = r_versions(platform),

--- a/drivers/windows/R/resource.R
+++ b/drivers/windows/R/resource.R
@@ -1,17 +1,17 @@
 ## windows-specific cluster functions, called from hipercow.
 
-windows_cluster_info <- function(config, path_root) {
+windows_cluster_info <- function(config, platform, path_root) {
   switch(config$cluster,
-         "wpia-hn" = cluster_info_wpia_hn(),
+         "wpia-hn" = cluster_info_wpia_hn(platform),
          cli::cli_abort(c(
            "Cluster '{config$cluster}' not supported by windows driver",
            i = "Use wpia-hn.")))
 }
 
 
-cluster_info_wpia_hn <- function() {
-  resources <- cluster_resources("wpia-hn", "hipercow.windows")
+cluster_info_wpia_hn <- function(platform) {
+  resources <- cluster_resources(platform)
   list(resources = resources,
-       r_versions = r_versions(),
+       r_versions = r_versions(platform),
        redis_url = resources$redis_url)
 }

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -1,6 +1,6 @@
-get_web_client <- function(platform) {
-  if (is.null(cache$web_client)) {
-    cache$web_client <- list()
+get_web_client <- function(platform = "windows") {
+  if (!is.list(cache$web_client)) {
+    assign("web_client", list(), envir = cache)
   }
   if (is.null(cache$web_client[[platform]])) {
     cache$web_client[[platform]] <- 
@@ -14,7 +14,8 @@ web_client <- R6::R6Class(
   cloneable = FALSE,
 
   public = list(
-    initialize = function(credentials, platform, cluster_default = NULL, 
+    initialize = function(credentials, platform = "windows", 
+                          cluster_default = NULL, 
                           login = FALSE, client = NULL) {
       private$client <- client %||% api_client$new(credentials)
       private$cluster <- cluster_name(cluster_default)
@@ -390,7 +391,7 @@ client_parse_log <- function(txt) {
 }
 
 
-client_parse_r_versions <- function(txt, platform) {
+client_parse_r_versions <- function(txt, platform = "windows") {
   dat <- from_json(txt)
   if (platform == "linux") {
     dat <- dat$linuxsoftware

--- a/drivers/windows/R/web.R
+++ b/drivers/windows/R/web.R
@@ -3,7 +3,7 @@ get_web_client <- function(platform = "windows") {
     assign("web_client", list(), envir = cache)
   }
   if (is.null(cache$web_client[[platform]])) {
-    cache$web_client[[platform]] <- 
+    cache$web_client[[platform]] <-
       web_client$new(windows_credentials(), platform, login = FALSE)
   }
   cache$web_client[[platform]]
@@ -14,8 +14,8 @@ web_client <- R6::R6Class(
   cloneable = FALSE,
 
   public = list(
-    initialize = function(credentials, platform = "windows", 
-                          cluster_default = NULL, 
+    initialize = function(credentials, platform = "windows",
+                          cluster_default = NULL,
                           login = FALSE, client = NULL) {
       private$client <- client %||% api_client$new(credentials)
       private$cluster <- cluster_name(cluster_default)

--- a/drivers/windows/tests/testthat/helper-hipercow.R
+++ b/drivers/windows/tests/testthat/helper-hipercow.R
@@ -1,3 +1,3 @@
 ## Ensures that tests work if offline
-cache$r_versions <- numeric_version(
-  c("4.2.3", "4.3.0", "4.3.2", "4.3.3", "4.4.0"))
+#cache$r_versions <- numeric_version(
+#  c("4.2.3", "4.3.0", "4.3.2", "4.3.3", "4.4.0"))

--- a/drivers/windows/tests/testthat/test-batch.R
+++ b/drivers/windows/tests/testthat/test-batch.R
@@ -37,7 +37,7 @@ test_that("batch data uses absolute paths", {
     hipercow::task_create_explicit(quote(sessionInfo()), driver = FALSE))
   dat <- template_data_task_run(id, config, path_root)
 
-  v <- version_string(config$r_version, ".")
+  v <- version_string(config$r_version[["windows"]], ".")
   expected <- sprintf("X:/b/c/hipercow/lib/windows/%s;I:/bootstrap/%s", v, v)
   expect_equal(dat$hipercow_library, expected)
 

--- a/drivers/windows/tests/testthat/test-bootstrap.R
+++ b/drivers/windows/tests/testthat/test-bootstrap.R
@@ -11,7 +11,8 @@ test_that("can run bootstrap", {
     file.path(root$path$root, "hipercow", "bootstrap-windows.R")))
   expect_equal(
     mockery::mock_args(mock_hipercow_provision)[[1]],
-    list("script", script = "hipercow/bootstrap-windows.R", root = root))
+    list("script", script = "hipercow/bootstrap-windows.R", root = root,
+         platform = "windows"))
   s <- readLines(file.path(root$path$root, "hipercow", "bootstrap-windows.R"))
   expect_match(s[[1]], "I:/bootstrap/")
 })
@@ -30,7 +31,8 @@ test_that("can run development bootstrap", {
     file.path(root$path$root, "hipercow", "bootstrap-windows.R")))
   expect_equal(
     mockery::mock_args(mock_hipercow_provision)[[1]],
-    list("script", script = "hipercow/bootstrap-windows.R", root = root))
+    list("script", script = "hipercow/bootstrap-windows.R", root = root,
+         platform = "windows"))
   s <- readLines(file.path(root$path$root, "hipercow", "bootstrap-windows.R"))
   expect_match(s[[1]], "I:/bootstrap-dev/")
   expect_match(
@@ -41,7 +43,8 @@ test_that("can run development bootstrap", {
 
 
 test_that("respond to option to select dev bootstrap", {
-  config <- list(r_version = numeric_version("4.3.2"))
+  config <- list(r_version = list("windows" = numeric_version("4.3.2"),
+                                  "linx" = numeric_version("4.3.3")))
   withr::with_options(
     list(hipercow.development = NULL),
     expect_equal(path_bootstrap(config), "I:/bootstrap/4.3.2"))
@@ -82,6 +85,6 @@ test_that("bootstrap iterates through correct versions", {
   mockery::expect_called(mock_update, 2)
   expect_equal(
     mockery::mock_args(mock_update),
-    list(list(development = NULL, root = NULL),
-         list(development = NULL, root = NULL)))
+    list(list(development = NULL, root = NULL, platform = "windows"),
+         list(development = NULL, root = NULL, platform = "windows")))
 })

--- a/drivers/windows/tests/testthat/test-cluster.R
+++ b/drivers/windows/tests/testthat/test-cluster.R
@@ -9,17 +9,17 @@ test_that("Can transform cluster names", {
 
 test_that("if r_versions cache is empty, call client", {
   prev <- cache$r_versions
-  rm(list = "r_versions", envir = cache)
+  suppressWarnings(rm(list = "r_versions", envir = cache))
   on.exit(cache$r_versions <- prev)
 
   versions <- numeric_version(c("4.2.3", "4.3.1"))
   fetch <- mockery::mock(versions)
   mockery::stub(r_versions, "r_versions_fetch", fetch)
   expect_equal(r_versions(), versions)
-  expect_equal(cache$r_versions, versions)
+  expect_equal(cache$r_versions[["windows"]], versions)
   mockery::expect_called(fetch, 1)
 
-  expect_equal(r_versions(), versions)
+  expect_equal(r_versions("windows"), versions)
   mockery::expect_called(fetch, 1)
 })
 

--- a/drivers/windows/tests/testthat/test-config.R
+++ b/drivers/windows/tests/testthat/test-config.R
@@ -9,8 +9,8 @@ test_that("Can create configuration", {
     c("cluster", "shares", "r_version", "path_lib"))
   expect_equal(config$cluster, "wpia-hn")
   expect_equal(config$shares, structure(list(shares), class = "dide_shares"))
-  expect_equal(config$r_version, numeric_version("4.3.0"))
-  expect_equal(config$path_lib, "hipercow/lib/windows/4.3.0")
+  expect_equal(config$r_version[["windows"]], numeric_version("4.3.0"))
+  expect_equal(config$path_lib[["windows"]], "hipercow/lib/windows/4.3.0")
   expect_equal(
     format(config$shares),
     c("1 configured:",
@@ -24,7 +24,7 @@ test_that("Select a sensible r version", {
   vmid <- numeric_version("4.2.3")
   expect_equal(select_r_version(vmax, valid = v), vmax)
   expect_error(select_r_version(numeric_version("3.6.0"), valid = v),
-               "Unsupported R version: 3.6.0")
+               "Unsupported R version 3.6.0 on windows")
   expect_equal(select_r_version(NULL, ours = vmid, valid = v), vmid)
   expect_equal(
     select_r_version(NULL, ours = numeric_version("4.2.0"), valid = v),

--- a/drivers/windows/tests/testthat/test-provision.R
+++ b/drivers/windows/tests/testthat/test-provision.R
@@ -23,7 +23,7 @@ test_that("can run provision script", {
   mockery::expect_called(mock_check, 1)
 
   mockery::expect_called(mock_get_client, 1)
-  expect_equal(mockery::mock_args(mock_get_client)[[1]], list())
+  expect_equal(mockery::mock_args(mock_get_client)[[1]], list("windows"))
 
   mockery::expect_called(mock_client$submit, 1)
   args <- mockery::mock_args(mock_client$submit)[[1]]

--- a/drivers/windows/tests/testthat/test-resource.R
+++ b/drivers/windows/tests/testthat/test-resource.R
@@ -1,6 +1,6 @@
 test_that("Cluster info returns something for wpia-hn", {
   config <- list(cluster = "wpia-hn")
-  res <- windows_cluster_info(config, "")
+  res <- windows_cluster_info(config)
   expect_setequal(names(res), c("resources", "r_versions", "redis_url"))
   expect_setequal(
     names(res$resources),

--- a/drivers/windows/tests/testthat/test-web.R
+++ b/drivers/windows/tests/testthat/test-web.R
@@ -4,12 +4,12 @@ test_that("can fetch cached web client", {
   cache$web_client <- NULL
   on.exit(cache$web_client <- NULL)
 
-  client <- get_web_client()
+  client <- get_web_client("platform")
   expect_false(client$logged_in())
   mockery::expect_called(mock_credentials, 1)
-  expect_identical(client, cache$web_client)
+  expect_identical(client, cache$web_client[["platform"]])
 
-  expect_identical(get_web_client(), client)
+  expect_identical(get_web_client("platform"), client)
   mockery::expect_called(mock_credentials, 1)
 })
 

--- a/drivers/windows/windows.Rproj
+++ b/drivers/windows/windows.Rproj
@@ -1,8 +1,8 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
-AlwaysSaveHistory: Default
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes

--- a/drivers/windows/windows.Rproj
+++ b/drivers/windows/windows.Rproj
@@ -12,6 +12,9 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source

--- a/hipercow.Rproj
+++ b/hipercow.Rproj
@@ -1,8 +1,8 @@
 Version: 1.0
 
-RestoreWorkspace: Default
-SaveWorkspace: Default
-AlwaysSaveHistory: Default
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: No
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes

--- a/man/hipercow_cluster_info.Rd
+++ b/man/hipercow_cluster_info.Rd
@@ -4,9 +4,15 @@
 \alias{hipercow_cluster_info}
 \title{Describe cluster}
 \usage{
-hipercow_cluster_info(driver = NULL, root = NULL)
+hipercow_cluster_info(platform = "windows", driver = NULL, root = NULL)
 }
 \arguments{
+\item{platform}{The operating system you are intending to run
+jobs on. By default this is \code{windows}, which we have traditionally
+supported, but the MS-HPC cluster also can support \code{linux} nodes.
+Where hipercow cluster drivers support multiple operating systems,
+you can specify which platform you would like information on here.}
+
 \item{driver}{The driver to use, which determines the cluster to
 fetch information from (depending on your configuration).  If no
 driver is configured, an error will be thrown.}

--- a/man/hipercow_cluster_info.Rd
+++ b/man/hipercow_cluster_info.Rd
@@ -4,20 +4,20 @@
 \alias{hipercow_cluster_info}
 \title{Describe cluster}
 \usage{
-hipercow_cluster_info(platform = "windows", driver = NULL, root = NULL)
+hipercow_cluster_info(driver = NULL, root = NULL, platform = "windows")
 }
 \arguments{
-\item{platform}{The operating system you are intending to run
-jobs on. By default this is \code{windows}, which we have traditionally
-supported, but the MS-HPC cluster also can support \code{linux} nodes.
-Where hipercow cluster drivers support multiple operating systems,
-you can specify which platform you would like information on here.}
-
 \item{driver}{The driver to use, which determines the cluster to
 fetch information from (depending on your configuration).  If no
 driver is configured, an error will be thrown.}
 
 \item{root}{Hipercow root, usually best \code{NULL}}
+
+\item{platform}{The operating system you are intending to run
+jobs on. By default this is \code{windows}, which we have traditionally
+supported, but the MS-HPC cluster also can support \code{linux} nodes.
+Where hipercow cluster drivers support multiple operating systems,
+you can specify which platform you would like information on here.}
 }
 \value{
 A list describing the cluster.  The details depend on the

--- a/man/hipercow_hello.Rd
+++ b/man/hipercow_hello.Rd
@@ -4,7 +4,12 @@
 \alias{hipercow_hello}
 \title{Hello world}
 \usage{
-hipercow_hello(progress = NULL, timeout = NULL, driver = NULL)
+hipercow_hello(
+  progress = NULL,
+  timeout = NULL,
+  driver = NULL,
+  platform = "windows"
+)
 }
 \arguments{
 \item{progress}{Logical value, indicating if a progress spinner
@@ -19,6 +24,12 @@ default is to wait forever.}
 be omitted where you have exactly one driver, but we error if
 not given when you have more than one driver, or if you have not
 configured any drivers.}
+
+\item{platform}{If the driver can target nodes running different
+operating systems, then we can run hello world targeting that
+platform. The default is \code{windows}, and \code{linux} can also be used
+to test linux nodes connected to our MS-HPC cluster with the
+hipercow.windows driver.}
 }
 \value{
 The string "Moo", direct from your cluster.

--- a/man/hipercow_provision.Rd
+++ b/man/hipercow_provision.Rd
@@ -10,6 +10,7 @@ hipercow_provision(
   driver = NULL,
   environment = "default",
   check_running_tasks = TRUE,
+  platform = "windows",
   root = NULL
 )
 }
@@ -38,6 +39,15 @@ while a package is in an inconsistent state, and on windows you
 may get a corrupted library if a package is upgraded while it is
 loaded.  You can disable this check by passing \code{FALSE}.  Not all
 drivers respond to this argument, but the windows driver does.}
+
+\item{platform}{The operating system that this provision should
+target. The default is \code{windows} as so far this has been the
+platform we have supported in DIDE. But as of Hipercow 1.0.54
+or later, the windows driver now also supports linux nodes
+connected to the MS-HPC headnode. To target jobs onto the linux
+nodes, you will need to provision a linux package repo, with
+\code{platform = 'linux'}. This is new and experimental, and the
+interface may change.}
 
 \item{root}{The hipercow root}
 }

--- a/man/hipercow_provision.Rd
+++ b/man/hipercow_provision.Rd
@@ -10,8 +10,8 @@ hipercow_provision(
   driver = NULL,
   environment = "default",
   check_running_tasks = TRUE,
-  platform = "windows",
-  root = NULL
+  root = NULL,
+  platform = "windows"
 )
 }
 \arguments{
@@ -40,6 +40,8 @@ may get a corrupted library if a package is upgraded while it is
 loaded.  You can disable this check by passing \code{FALSE}.  Not all
 drivers respond to this argument, but the windows driver does.}
 
+\item{root}{The hipercow root}
+
 \item{platform}{The operating system that this provision should
 target. The default is \code{windows} as so far this has been the
 platform we have supported in DIDE. But as of Hipercow 1.0.54
@@ -48,8 +50,6 @@ connected to the MS-HPC headnode. To target jobs onto the linux
 nodes, you will need to provision a linux package repo, with
 \code{platform = 'linux'}. This is new and experimental, and the
 interface may change.}
-
-\item{root}{The hipercow root}
 }
 \value{
 Nothing

--- a/man/hipercow_provision_compare.Rd
+++ b/man/hipercow_provision_compare.Rd
@@ -4,7 +4,13 @@
 \alias{hipercow_provision_compare}
 \title{Compare installations}
 \usage{
-hipercow_provision_compare(curr = 0, prev = -1, driver = NULL, root = NULL)
+hipercow_provision_compare(
+  curr = 0,
+  prev = -1,
+  driver = NULL,
+  root = NULL,
+  platform = "windows"
+)
 }
 \arguments{
 \item{curr}{The previous installation to compare against. Can be a
@@ -26,6 +32,15 @@ you want to compare against the empty installation.}
 blank if only one is configured (this will be typical).}
 
 \item{root}{The hipercow root}
+
+\item{platform}{The operating system that this provision should
+target. The default is \code{windows} as so far this has been the
+platform we have supported in DIDE. But as of Hipercow 1.0.54
+or later, the windows driver now also supports linux nodes
+connected to the MS-HPC headnode. To target jobs onto the linux
+nodes, you will need to provision a linux package repo, with
+\code{platform = 'linux'}. This is new and experimental, and the
+interface may change.}
 }
 \value{
 An object of class \code{conan_compare}, which can be printed

--- a/man/hipercow_provision_list.Rd
+++ b/man/hipercow_provision_list.Rd
@@ -5,14 +5,15 @@
 \alias{hipercow_provision_check}
 \title{List installations}
 \usage{
-hipercow_provision_list(driver = NULL, root = NULL)
+hipercow_provision_list(driver = NULL, root = NULL, platform = "windows")
 
 hipercow_provision_check(
   method = NULL,
   ...,
   driver = NULL,
   environment = "default",
-  root = NULL
+  root = NULL,
+  platform = "windows"
 )
 }
 \arguments{
@@ -20,6 +21,15 @@ hipercow_provision_check(
 blank if only one is configured (this will be typical).}
 
 \item{root}{The hipercow root}
+
+\item{platform}{The operating system that this provision should
+target. The default is \code{windows} as so far this has been the
+platform we have supported in DIDE. But as of Hipercow 1.0.54
+or later, the windows driver now also supports linux nodes
+connected to the MS-HPC headnode. To target jobs onto the linux
+nodes, you will need to provision a linux package repo, with
+\code{platform = 'linux'}. This is new and experimental, and the
+interface may change.}
 
 \item{method}{The provisioning method to use, defaulting to
 \code{NULL}, which indicates we should try and detect the best

--- a/man/hipercow_resources_validate.Rd
+++ b/man/hipercow_resources_validate.Rd
@@ -19,9 +19,16 @@ hipercow_resources_validate(
 blank if only one is configured (this will be typical).}
 
 \item{root}{The hipercow root}
+
+\item{platform}{The MS-HPC cluster targeted by the hipercow.windows
+driver, supports both windows and linux nodes, which may have
+different capabilities and software versions. Specify a platform
+here (\code{windows} is the default, or \code{linux}) to validate resources
+against the node capabilities available for that platform.}
 }
 \value{
-TRUE if the resources are compatible with this driver.
+TRUE if the resources are compatible with this driver
+and platform.
 }
 \description{
 Query a driver to find information about the cluster, and then validate

--- a/man/hipercow_resources_validate.Rd
+++ b/man/hipercow_resources_validate.Rd
@@ -4,7 +4,12 @@
 \alias{hipercow_resources_validate}
 \title{Validate a \code{hipercow_resources} list for a driver.}
 \usage{
-hipercow_resources_validate(resources, driver = NULL, root = NULL)
+hipercow_resources_validate(
+  resources,
+  platform = "windows",
+  driver = NULL,
+  root = NULL
+)
 }
 \arguments{
 \item{resources}{A \link{hipercow_resources} list returned by

--- a/man/hipercow_resources_validate.Rd
+++ b/man/hipercow_resources_validate.Rd
@@ -6,9 +6,9 @@
 \usage{
 hipercow_resources_validate(
   resources,
-  platform = "windows",
   driver = NULL,
-  root = NULL
+  root = NULL,
+  platform = "windows"
 )
 }
 \arguments{

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -201,7 +201,7 @@ clear_cached_roots <- function() {
   }
 }
 
-elsewhere_cluster_info <- function(config, platform, path_root) {
+elsewhere_cluster_info <- function(config, path_root, platform) {
   resources <- list(max_ram = 16, max_cores = 8, queues = c("Aldi", "Tesco"),
                     nodes = c("kevin", "stuart"), default_queue = "Aldi")
   redis_url <- NULL

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -141,7 +141,7 @@ elsewhere_provision_run <- function(args, check_running_tasks,
 
 
 
-elsewhere_provision_list <- function(args, config, path_root) {
+elsewhere_provision_list <- function(args, config, path_root, platform) {
   if (is.null(args)) {
     hash <- NULL
   } else {
@@ -156,7 +156,8 @@ elsewhere_provision_list <- function(args, config, path_root) {
 }
 
 
-elsewhere_provision_compare <- function(curr, prev, config, path_root) {
+elsewhere_provision_compare <- function(curr, prev, config, path_root,
+                                        platform) {
   path_lib <- file.path(config$path, "hipercow", "lib")
   conan2::conan_compare(path_lib, curr, prev)
 }

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -118,8 +118,8 @@ elsewhere_cancel <- function(id, config, path_root) {
 }
 
 
-elsewhere_provision_run <- function(args, check_running_tasks, config,
-                                    path_root) {
+elsewhere_provision_run <- function(args, check_running_tasks, platform,
+                                    config, path_root) {
   show_log <- args$show_log %||% FALSE
   args$show_log <- NULL
   path_bootstrap <- find_library_with("pkgdepends")
@@ -201,7 +201,7 @@ clear_cached_roots <- function() {
   }
 }
 
-elsewhere_cluster_info <- function(config, path_root) {
+elsewhere_cluster_info <- function(config, platform, path_root) {
   resources <- list(max_ram = 16, max_cores = 8, queues = c("Aldi", "Tesco"),
                     nodes = c("kevin", "stuart"), default_queue = "Aldi")
   redis_url <- NULL

--- a/tests/testthat/helper-hipercow.R
+++ b/tests/testthat/helper-hipercow.R
@@ -118,8 +118,8 @@ elsewhere_cancel <- function(id, config, path_root) {
 }
 
 
-elsewhere_provision_run <- function(args, check_running_tasks, platform,
-                                    config, path_root) {
+elsewhere_provision_run <- function(args, check_running_tasks,
+                                    config, path_root, platform) {
   show_log <- args$show_log %||% FALSE
   args$show_log <- NULL
   path_bootstrap <- find_library_with("pkgdepends")
@@ -176,7 +176,7 @@ elsewhere_keypair <- function(config, path_root) {
 }
 
 
-elsewhere_check_hello <- function(config, path_root) {
+elsewhere_check_hello <- function(config, path_root, platform) {
 }
 
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -175,7 +175,7 @@ test_that("can call provision", {
   expect_equal(
     mockery::mock_args(mock_provision)[[1]],
     list(list(method = NULL, environment = environment, show_log = FALSE),
-         TRUE, config, path_root, platform = "windows"))
+         TRUE, config, path_root, "windows"))
 })
 
 
@@ -198,7 +198,7 @@ test_that("can call provision_list", {
   mockery::expect_called(mock_provision_list, 1)
   expect_equal(
     mockery::mock_args(mock_provision_list)[[1]],
-    list(NULL, config, path_root))
+    list(NULL, config, path_root, "windows"))
 })
 
 
@@ -222,7 +222,8 @@ test_that("can call provision_check", {
   mockery::expect_called(mock_provision_list, 1)
   expect_equal(
     mockery::mock_args(mock_provision_list)[[1]],
-    list(list(method = NULL, environment = env), config, path_root))
+    list(list(method = NULL, environment = env), config, path_root,
+         "windows"))
 
   hipercow_provision_check(method = "script", script = "foo.R",
                            root = path_here)
@@ -230,7 +231,7 @@ test_that("can call provision_check", {
   expect_equal(
     mockery::mock_args(mock_provision_list)[[2]],
     list(list(method = "script", environment = env, script = "foo.R"),
-         config, path_root))
+         config, path_root, "windows"))
 })
 
 
@@ -253,7 +254,7 @@ test_that("can call provision_compare", {
   mockery::expect_called(mock_provision_compare, 1)
   expect_equal(
     mockery::mock_args(mock_provision_compare)[[1]],
-    list(0, -1, config, path_root))
+    list(0, -1, config, path_root, "windows"))
 })
 
 

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -175,7 +175,7 @@ test_that("can call provision", {
   expect_equal(
     mockery::mock_args(mock_provision)[[1]],
     list(list(method = NULL, environment = environment, show_log = FALSE),
-         TRUE, config, path_root))
+         TRUE, config, path_root, platform = "windows"))
 })
 
 


### PR DESCRIPTION
A bit gnarly - and hopefully a good place to stop. Functionally nothing should change with this PR; there is no actual linux-handling yet, but it prepares the way by taking a `platform` argument to various functions, and storing a few things as a list per-platform as required. For now all the extra platform args are set to `windows` by default, so the tests also don't change too much, except where they specifically look at the args.

Main hipercow: these functions now allow `platform` to be specified - the idea being these are done at a time where we haven't set resources for the resources/queue a task should run on, so we could be thinking about either platform here

hipercow_hello
hipercow_provision
hipercow_provision_list
hipercow_provision_check
hipercow_provision_compare
hipercow_resources_validate

hipercow_configure - I've left to handle this through the existing `...` for now, since not all drivers will support multiple platforms - which makes me wonder if `...` might not be better for the 5 functions above - I'm not quite sure. But have to start somewhere. 

Then in hipercow.windows, the places where `platform` gets added flow naturally from the above. Actual code changes in hipercow.windows:-

* `config$r_versions` and `config$path_lib` used to be a vector of versions and a string respectively; each is now a list of potentially two of the above, named `windows` and `linux`. It's not a very nice idea but I think we need to be prepared to have different available r_versions on the different platforms.
* We also need, I think, a web_client per platform, with the platform name and other platform-specific things as private properties. web_client gets cached, so we now have a list of two web clients cached - the reuslts of the cluster_resources and r_versions api-calls also get cached, and are now lists too.
* Places that use config$path_lib then follow - so the building of the package path, including the bootstrap library. These do not exist yet, but the code will expect (or create) `bootstrap-linux` and `bootstrap-linux-dev` folders, with R versions within, alongside the "default" existing win versions.
* And the creating of the task from the template require path_lib, so changes in there to swith on platform...

At this point, I _believe_ we have something still consistent with no changes for windows users, but all the scaffolding to start acting on when a different platform is specified... 