### PR TITLE
Allow changing redis url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow
 Title: High Performance Computing
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/configure.R
+++ b/R/configure.R
@@ -20,6 +20,11 @@
 ##'   cluster. You can use this option to choose a specific version
 ##'   (e.g., pass "4.3.0" to select exactly that version).
 ##'
+##' * `redis_url`: Control the URL used to connect to Redis.  You can
+##'   use this to use an alternative Redis host, which is unlikely
+##'   unless we have suggested you do this.  The default (`NULL`) uses
+##'   the Redis server on the headnode.
+##'
 ##' See `vignette("details")` for more information about these options.
 ##'
 ##' @title Configure your hipercow root

--- a/drivers/dide/DESCRIPTION
+++ b/drivers/dide/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hipercow.dide
 Title: HPC Support for the DIDE cluster
-Version: 1.1.3
+Version: 1.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/drivers/dide/R/batch.R
+++ b/drivers/dide/R/batch.R
@@ -19,6 +19,8 @@ template_data_task_run <- function(task_id, config, path_root) {
     remote_path(path_to_task_file(path_root, task_id, "Renviron"),
                 config$shares, config$platform)
 
+  data$redis_url <- config$redis_url %||% "10.0.2.254"
+
   data
 }
 

--- a/drivers/dide/R/config.R
+++ b/drivers/dide/R/config.R
@@ -1,10 +1,22 @@
 linux_configure <- function(shares = NULL, r_version = NULL,
-                            platform = "linux") {
-  windows_configure(shares, r_version, platform)
+                            redis_url = NULL) {
+  dide_configure(shares = shares,
+                 r_version = r_version,
+                 redis_url = redis_url,
+                 platform = "linux")
 }
 
+
 windows_configure <- function(shares = NULL, r_version = NULL,
-                              platform = "windows") {
+                              redis_url = NULL) {
+  dide_configure(shares = shares,
+                 r_version = r_version,
+                 redis_url = redis_url,
+                 platform = "windows")
+}
+
+
+dide_configure <- function(shares, r_version, redis_url, platform) {
   platform <- match_value(platform, c("windows", "linux"))
   path <- getwd()
   r_version <- select_r_version(r_version, valid = r_versions(platform))
@@ -12,10 +24,15 @@ windows_configure <- function(shares = NULL, r_version = NULL,
   path_lib <- file.path("hipercow", "lib", platform, r_version_str)
   stopifnot(fs::dir_exists(file.path(path, "hipercow")))
   fs::dir_create(file.path(path, path_lib))
+  if (!is.null(redis_url)) {
+    assert_scalar_character(redis_url)
+  }
   list(cluster = "wpia-hn",
        shares = dide_cluster_paths(shares, path, platform),
+       redis_url = redis_url,
        r_version = r_version,
        path_lib = unix_path_slashes(path_lib),
+       redis_url = redis_url,
        platform = platform)
 }
 

--- a/drivers/dide/R/config.R
+++ b/drivers/dide/R/config.R
@@ -32,7 +32,6 @@ dide_configure <- function(shares, r_version, redis_url, platform) {
        redis_url = redis_url,
        r_version = r_version,
        path_lib = unix_path_slashes(path_lib),
-       redis_url = redis_url,
        platform = platform)
 }
 

--- a/drivers/dide/R/resource.R
+++ b/drivers/dide/R/resource.R
@@ -12,5 +12,5 @@ dide_cluster_info <- function(config, path_root) {
   resources <- cluster_resources(config$platform)
   list(resources = resources,
        r_versions = r_versions(config$platform),
-       redis_url = resources$redis_url)
+       redis_url = config$redis_url %||% resources$redis_url)
 }

--- a/drivers/dide/inst/templates/task_run.bat
+++ b/drivers/dide/inst/templates/task_run.bat
@@ -20,7 +20,7 @@ set R_ENVIRON_USER={{renviron_path}}
 set HIPERCOW_NO_DRIVERS=1
 set RENV_AUTOLOADER_ENABLED=FALSE
 set HIPERCOW_CORES=%CCP_NUMCPUS%
-set REDIS_URL=10.0.2.254
+set REDIS_URL={{redis_url}}
 
 ECHO this is a single task
 

--- a/drivers/dide/inst/templates/task_run.sh
+++ b/drivers/dide/inst/templates/task_run.sh
@@ -22,7 +22,7 @@ export R_ENVIRON_USER={{renviron_path}}
 export HIPERCOW_NO_DRIVERS=1
 export RENV_AUTOLOADER_ENABLED=FALSE
 export HIPERCOW_CORES=$CCP_NUMCPUS
-export REDIS_URL=10.0.2.254
+export REDIS_URL={{redis_url}}
 
 echo this is a single task
 

--- a/drivers/dide/tests/testthat/helper-config.R
+++ b/drivers/dide/tests/testthat/helper-config.R
@@ -5,10 +5,10 @@ example_root <- function(mount_path, sub = "b/c", redis_url = NULL) {
   path <- normalize_path(path)
   shares <- dide_path(mount_path, "//host/share/path", "X:")
   suppressMessages(
-    hipercow::hipercow_configure("dide-windows", shares = shares, 
+    hipercow::hipercow_configure("dide-windows", shares = shares,
                                  redis_url = redis_url, root = root))
   suppressMessages(
-    hipercow::hipercow_configure("dide-linux", shares = shares, 
+    hipercow::hipercow_configure("dide-linux", shares = shares,
                                  redis_url = redis_url, root = root))
   root
 }

--- a/drivers/dide/tests/testthat/helper-config.R
+++ b/drivers/dide/tests/testthat/helper-config.R
@@ -5,11 +5,9 @@ example_root <- function(mount_path, sub = "b/c") {
   path <- normalize_path(path)
   shares <- dide_path(mount_path, "//host/share/path", "X:")
   suppressMessages(
-    hipercow::hipercow_configure("dide-windows", shares = shares, root = root,
-                                 platform = "windows"))
+    hipercow::hipercow_configure("dide-windows", shares = shares, root = root))
   suppressMessages(
-    hipercow::hipercow_configure("dide-linux", shares = shares, root = root,
-                                 platform = "linux"))
+    hipercow::hipercow_configure("dide-linux", shares = shares, root = root))
   root
 }
 

--- a/drivers/dide/tests/testthat/helper-config.R
+++ b/drivers/dide/tests/testthat/helper-config.R
@@ -1,13 +1,13 @@
-example_root <- function(mount_path, sub = "b/c") {
+example_root <- function(mount_path, sub = "b/c", redis_url = NULL) {
   fs::dir_create(mount_path)
   path <- file.path(mount_path, sub)
   root <- suppressMessages(hipercow::hipercow_init(path))
   path <- normalize_path(path)
   shares <- dide_path(mount_path, "//host/share/path", "X:")
   suppressMessages(
-    hipercow::hipercow_configure("dide-windows", shares = shares, root = root))
+    hipercow::hipercow_configure("dide-windows", shares = shares, redis_url = redis_url, root = root))
   suppressMessages(
-    hipercow::hipercow_configure("dide-linux", shares = shares, root = root))
+    hipercow::hipercow_configure("dide-linux", shares = shares, redis_url = redis_url, root = root))
   root
 }
 

--- a/drivers/dide/tests/testthat/helper-config.R
+++ b/drivers/dide/tests/testthat/helper-config.R
@@ -5,9 +5,11 @@ example_root <- function(mount_path, sub = "b/c", redis_url = NULL) {
   path <- normalize_path(path)
   shares <- dide_path(mount_path, "//host/share/path", "X:")
   suppressMessages(
-    hipercow::hipercow_configure("dide-windows", shares = shares, redis_url = redis_url, root = root))
+    hipercow::hipercow_configure("dide-windows", shares = shares, 
+                                 redis_url = redis_url, root = root))
   suppressMessages(
-    hipercow::hipercow_configure("dide-linux", shares = shares, redis_url = redis_url, root = root))
+    hipercow::hipercow_configure("dide-linux", shares = shares, 
+                                 redis_url = redis_url, root = root))
   root
 }
 

--- a/drivers/dide/tests/testthat/test-batch.R
+++ b/drivers/dide/tests/testthat/test-batch.R
@@ -104,3 +104,17 @@ test_that("can write a provision batch file for linux", {
     c("test", "path", "b", "c", "hipercow", "provision", id,
       "wrap_provision.sh"))
 })
+
+
+test_that("can set redis url in batch file", {
+  mount <- withr::local_tempfile()
+  root <- example_root(mount, "b/c", redis_url = "redis.example.com")
+  path_root <- root$path$root
+  config <- root$config[["dide-windows"]]
+  id <- withr::with_dir(
+    path_root,
+    hipercow::task_create_explicit(quote(sessionInfo()), driver = FALSE))
+  write_batch_task_run_windows(id, config, path_root)
+  path_batch <- path_to_task_file(path_root, id, "run.bat")
+  expect_true("set REDIS_URL=redis.example.com" %in% readLines(path_batch))
+})

--- a/drivers/dide/tests/testthat/test-config.R
+++ b/drivers/dide/tests/testthat/test-config.R
@@ -80,3 +80,23 @@ test_that("can warn about old R versions", {
     res2$messages[[5]],
     "Your local R installation is very old")
 })
+
+
+test_that("can use an alternative redis server", {
+  mount <- withr::local_tempfile()
+  path <- file.path(mount, "b", "c")
+  root <- suppressMessages(hipercow::hipercow_init(path))
+  shares <- dide_path(mount, "//host/share/path", "X:")
+  cmp <- withr::with_dir(
+    path,
+    windows_configure(shares, "4.5.0", "redis.example.com"))
+
+  suppressMessages(
+    hipercow::hipercow_configure(driver = "dide-windows",
+                                 shares = shares,
+                                 redis_url = "redis.example.com",
+                                 r_version = "4.5.0",
+                                 root = root))
+  expect_equal(root$config[["dide-windows"]], cmp)
+  expect_equal(cmp$redis_url, "redis.example.com")
+})

--- a/drivers/dide/tests/testthat/test-config.R
+++ b/drivers/dide/tests/testthat/test-config.R
@@ -3,14 +3,14 @@ test_that("Can create configuration", {
   path <- file.path(mount, "b", "c")
   root <- suppressMessages(hipercow::hipercow_init(path))
   shares <- dide_path(mount, "//host/share/path", "X:")
-  config <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
+  config <- withr::with_dir(path, windows_configure(shares, "4.5.0"))
   expect_setequal(
     names(config),
-    c("cluster", "shares", "r_version", "path_lib", "platform"))
+    c("cluster", "shares", "r_version", "path_lib", "platform", "redis_url"))
   expect_equal(config$cluster, "wpia-hn")
   expect_equal(config$shares, structure(list(shares), class = "dide_shares"))
-  expect_equal(config$r_version, numeric_version("4.3.0"))
-  expect_equal(config$path_lib, "hipercow/lib/windows/4.3.0")
+  expect_equal(config$r_version, numeric_version("4.5.0"))
+  expect_equal(config$path_lib, "hipercow/lib/windows/4.5.0")
   expect_equal(
     format(config$shares),
     c("1 configured:",
@@ -37,12 +37,12 @@ test_that("can configure a root", {
   path <- file.path(mount, "b", "c")
   root <- suppressMessages(hipercow::hipercow_init(path))
   shares <- dide_path(mount, "//host/share/path", "X:")
-  cmp <- withr::with_dir(path, windows_configure(shares, "4.3.0"))
+  cmp <- withr::with_dir(path, windows_configure(shares, "4.5.0"))
 
   suppressMessages(
     hipercow::hipercow_configure(driver = "dide-windows",
                                  shares = shares,
-                                 r_version = "4.3.0",
+                                 r_version = "4.5.0",
                                  root = root))
   expect_equal(root$config[["dide-windows"]], cmp)
 })

--- a/man/hipercow_configure.Rd
+++ b/man/hipercow_configure.Rd
@@ -35,6 +35,10 @@ cluster. Typically hipercow will choose a version close to the
 one you are using to submit jobs, of the set available on the
 cluster. You can use this option to choose a specific version
 (e.g., pass "4.3.0" to select exactly that version).
+\item \code{redis_url}: Control the URL used to connect to Redis.  You can
+use this to use an alternative Redis host, which is unlikely
+unless we have suggested you do this.  The default (\code{NULL}) uses
+the Redis server on the headnode.
 }
 
 See \code{vignette("details")} for more information about these options.


### PR DESCRIPTION
Small tweak in the end - adds a new configuration option which seems to do the trick

```
library(hipercow)
hipercow_configure("dide-windows", redis_url = "wpia-hn2b.hpc.dide.ic.ac.uk")
hipercow_configuration()
r <- hipercow_rrq_controller()
redux::parse_info(r$con$INFO())$redis_version
```