### PR TITLE
Improve rrq worker submission with multiple known redis servers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     prettyunits,
     redux,
     rmarkdown,
-    rrq (>= 0.7.20),
+    rrq (>= 0.7.23),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Remotes:

--- a/R/configure.R
+++ b/R/configure.R
@@ -244,7 +244,7 @@ hipercow_driver_create <- function(driver, call = NULL) {
 
   pkg <- drivers[[driver]][[1]]
   target <- drivers[[driver]][[2]]
-  ns <- ensure_package(pkg, call)
+  ns <- ensure_package(pkg, call = call)
 
   ## Users should never see these errors, we are in control of our own
   ## drivers; these just help us if we're writing new ones.

--- a/R/dide.R
+++ b/R/dide.R
@@ -22,7 +22,7 @@
 ##'
 ##' dide_authenticate()
 dide_authenticate <- function() {
-  ns <- ensure_package("hipercow.dide", rlang::current_env())
+  ns <- ensure_package("hipercow.dide")
   ns$dide_authenticate(call = rlang::current_env())
 }
 
@@ -44,7 +44,7 @@ dide_authenticate <- function() {
 ##'
 ##' dide_check()
 dide_check <- function(path = getwd()) {
-  ns <- ensure_package("hipercow.dide", rlang::current_env())
+  ns <- ensure_package("hipercow.dide")
   ns$dide_check(path, call = rlang::current_env())
 }
 
@@ -94,9 +94,8 @@ dide_check <- function(path = getwd()) {
 ##' hipercow_configure("dide-windows", shares = share)
 dide_path <- function(path_local, path_remote, drive_remote, call = NULL) {
   call <- call %||% rlang::current_env()
-  ns <- ensure_package("hipercow.dide", call)
-  ns$dide_path(path_local, path_remote, drive_remote,
-                  call = call)
+  ns <- ensure_package("hipercow.dide")
+  ns$dide_path(path_local, path_remote, drive_remote, call = call)
 }
 
 
@@ -116,7 +115,7 @@ dide_path <- function(path_local, path_remote, drive_remote, call = NULL) {
 ##' # Return your DIDE username
 ##' dide_username()
 dide_username <- function() {
-  ns <- ensure_package("hipercow.dide", rlang::current_env())
+  ns <- ensure_package("hipercow.dide")
   ns$dide_username(call = rlang::current_env())
 }
 
@@ -142,6 +141,6 @@ dide_username <- function() {
 ##' # Generate a new keypair, if one does not exist
 ##' dide_generate_keypair()
 dide_generate_keypair <- function(update = FALSE) {
-  ns <- ensure_package("hipercow.dide", rlang::current_env())
+  ns <- ensure_package("hipercow.dide")
   ns$dide_generate_keypair(update = update, call = rlang::current_env())
 }

--- a/R/provision.R
+++ b/R/provision.R
@@ -132,7 +132,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
   ## and we'll need to handle that too.
   root <- hipercow_root(root)
   assert_scalar_logical(check_running_tasks)
-  ensure_package("conan2", rlang::current_env())
+  ensure_package("conan2")
   env <- environment_load(environment, root, rlang::current_env())
   args <- list(method = method, environment = env, ...)
 
@@ -186,7 +186,7 @@ hipercow_provision <- function(method = NULL, ..., driver = NULL,
 ##' cleanup()
 hipercow_provision_list <- function(driver = NULL, root = NULL) {
   root <- hipercow_root(root)
-  ensure_package("conan2", rlang::current_env())
+  ensure_package("conan2")
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
   dat$driver$provision_list(NULL, dat$config, root$path$root)
@@ -199,7 +199,7 @@ hipercow_provision_check <- function(method = NULL, ..., driver = NULL,
                                      environment = "default",
                                      root = NULL) {
   root <- hipercow_root(root)
-  ensure_package("conan2", rlang::current_env())
+  ensure_package("conan2")
   env <- environment_load(environment, root, rlang::current_env())
   args <- list(method = method, environment = env, ...)
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
@@ -243,7 +243,7 @@ hipercow_provision_check <- function(method = NULL, ..., driver = NULL,
 hipercow_provision_compare <- function(curr = 0, prev = -1, driver = NULL,
                                        root = NULL) {
   root <- hipercow_root(root)
-  ensure_package("conan2", rlang::current_env())
+  ensure_package("conan2")
   driver <- hipercow_driver_select(driver, TRUE, root, rlang::current_env())
   dat <- hipercow_driver_prepare(driver, root, rlang::current_env())
   dat$driver$provision_compare(curr, prev, dat$config, root$path$root)

--- a/tests/testthat/test-configure.R
+++ b/tests/testthat/test-configure.R
@@ -174,7 +174,7 @@ test_that("creating a package loads function and calls target function", {
 
   mockery::expect_called(mock_ensure_package, 1)
   expect_equal(mockery::mock_args(mock_ensure_package)[[1]],
-               list("hipercow.dide", NULL))
+               list("hipercow.dide", call = NULL))
   mockery::expect_called(mock_ns$hipercow_driver_windows, 1)
   expect_equal(mockery::mock_args(mock_ns$hipercow_driver_windows)[[1]],
                list())

--- a/tests/testthat/test-dide.R
+++ b/tests/testthat/test-dide.R
@@ -7,8 +7,7 @@ test_that("dide_path calls hipercow.dide", {
 
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
-  expect_equal(args[[1]], "hipercow.dide")
-  expect_type(args[[2]], "environment")
+  expect_equal(args, list("hipercow.dide"))
 
   mockery::expect_called(mock_pkg$dide_path, 1)
   args <- mockery::mock_args(mock_pkg$dide_path)[[1]]
@@ -27,8 +26,7 @@ test_that("dide authenticate passes through to hipercow.dide", {
 
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
-  expect_equal(args[[1]], "hipercow.dide")
-  expect_type(args[[2]], "environment")
+  expect_equal(args, list("hipercow.dide"))
 
   mockery::expect_called(mock_pkg$dide_authenticate, 1)
   args <- mockery::mock_args(mock_pkg$dide_authenticate)[[1]]
@@ -45,8 +43,7 @@ test_that("dide username passes through to hipercow.dide", {
 
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
-  expect_equal(args[[1]], "hipercow.dide")
-  expect_type(args[[2]], "environment")
+  expect_equal(args, list("hipercow.dide"))
 
   mockery::expect_called(mock_pkg$dide_username, 1)
   args <- mockery::mock_args(mock_pkg$dide_username)[[1]]
@@ -64,7 +61,6 @@ test_that("dide check passes through to hipercow.dide", {
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
   expect_equal(args[[1]], "hipercow.dide")
-  expect_type(args[[2]], "environment")
 
   mockery::expect_called(mock_pkg$dide_check, 1)
   args <- mockery::mock_args(mock_pkg$dide_check)[[1]]
@@ -83,8 +79,7 @@ test_that("dide keypair passes through to hipercow.dide", {
 
   mockery::expect_called(mock_ensure_package, 1)
   args <- mockery::mock_args(mock_ensure_package)[[1]]
-  expect_equal(args[[1]], "hipercow.dide")
-  expect_type(args[[2]], "environment")
+  expect_equal(args, list("hipercow.dide"))
 
   mockery::expect_called(mock_pkg$dide_generate_keypair, 1)
   args <- mockery::mock_args(mock_pkg$dide_generate_keypair)[[1]]


### PR DESCRIPTION
This PR fixes two semi-related bugs.  The first was hiding the root cause of the second.

First, we pass additional closures to rrq spawn - this helps identify the underlying problem. Rather than workers being waited on forever we now error as soon as they have died and report the logs.  This uses tweaks made in https://github.com/mrc-ide/rrq/pull/129

Second, we cope with a situation where the redis server has changed